### PR TITLE
Fix MW bug in bindc ex8

### DIFF
--- a/source/bind/c/samples/rp1311_example8.c
+++ b/source/bind/c/samples/rp1311_example8.c
@@ -75,6 +75,7 @@ int main(void) {
     cea_rocket_solution_get_property(soln, CEA_ROCKET_TEMPERATURE, num_pts, temperature);
     cea_rocket_solution_get_property(soln, CEA_ROCKET_PRESSURE, num_pts, pressure);
     cea_rocket_solution_get_property(soln, CEA_ROCKET_GAMMA_S, num_pts, gamma);
+    cea_rocket_solution_get_property(soln, CEA_ROCKET_M, num_pts, mw);
     cea_rocket_solution_get_property(soln, CEA_MACH, num_pts, mach);
     cea_rocket_solution_get_property(soln, CEA_AE_AT, num_pts, area_ratio);
     cea_rocket_solution_get_property(soln, CEA_ISP, num_pts, isp);
@@ -83,7 +84,7 @@ int main(void) {
 
     printf(
         "%10s %10s %10s %10s %10s %10s %10s %10s %10s \n",
-        "T (K)", "P (bar)", "gamma_s", "MW", "Mach", "Ae/At", "ISP", "C* (m/s)", "C_f"
+        "T (K)", "P (bar)", "gamma_s", "M (1/n)", "Mach", "Ae/At", "ISP", "C* (m/s)", "C_f"
     );
 
     for (int i = 0; i < num_pts; ++i) {


### PR DESCRIPTION
## Summary
source/bind/c/samples/rp1311_example8.c declares and prints a molecular weight term, but never reads it from the solution.

## Changes
Added call to populate MW variable.  Chose to use the CEA_ROCKET_M parameter for direct comparison to RP-1311 Part II.
Changed label from MW to M (1/n) to match RP-1311 Part II.

## Testing
Development test cases run locally and via github actions.

### Output before change
Note zeros in MW, but was never initialized, so result isn't well defined.
```
     T (K)    P (bar)    gamma_s         MW       Mach      Ae/At        ISP   C* (m/s)        C_f
 3383.8446     53.3172      1.1447      0.0000     0.0000  0.0000e+00  0.0000e+00  2.3323e+03  0.0000e+00
 3185.6731     30.6554      1.1468        -nan     1.0000  1.0000e+00  1.5379e+03  2.3323e+03  6.5939e-01
 2567.3402      5.3317      1.1725      0.0000     2.1487  2.3503e+00  2.9674e+03  2.3323e+03  1.2723e+00
 3348.6869     48.3822      1.1449      0.0000     0.4132  1.5800e+00  6.5359e+02  2.3323e+03  2.8023e-01
 1468.1627      0.2049      1.2428      0.0000     3.8482  2.5000e+01  4.1244e+03  2.3323e+03  1.7684e+00
```
 
###  Output after change
```
     T (K)    P (bar)    gamma_s    M (1/n)       Mach      Ae/At        ISP   C* (m/s)        C_f
 3383.8446     53.3172      1.1447     12.7157     0.0000  0.0000e+00  0.0000e+00  2.3323e+03  0.0000e+00
 3185.6731     30.6554      1.1468     12.8432     1.0000  1.0000e+00  1.5379e+03  2.3323e+03  6.5939e-01
 2567.3402      5.3317      1.1725     13.1231     2.1487  2.3503e+00  2.9674e+03  2.3323e+03  1.2723e+00
 3348.6869     48.3822      1.1449     12.7391     0.4132  1.5800e+00  6.5359e+02  2.3323e+03  2.8023e-01
 1468.1627      0.2049      1.2428     13.2071     3.8482  2.5000e+01  4.1244e+03  2.3323e+03  1.7684e+00
```

## Compatibility / Numerical behavior
- [x] No expected changes to numerical results
- [ ] Expected changes (explain and provide validation)

## Notes
The match to RP-1311 isn't perfect, but that's true for the full solution in general.