### PR TITLE
Fix length of elements & coefficients for reactants whose formula was specified via input file

### DIFF
--- a/source/input.f90
+++ b/source/input.f90
@@ -625,7 +625,7 @@ contains
 
         type(Formula) :: f
         integer, parameter :: max_values = 16
-        integer :: n, ierr
+        integer :: i, n, ierr
         character(:), allocatable :: word
 
         allocate(f%elements(max_values))
@@ -638,7 +638,7 @@ contains
         f%elements(n) = token
         f%coefficients(n) = scanner%read_real()
 
-        do n = 2,size(f%elements)
+        do i = 2,size(f%elements)
             word = scanner%peek_word(ierr)
             if (ierr /= 0) exit  ! Buffer empty
             select case(word(1:1))
@@ -647,8 +647,9 @@ contains
                     if (len_trim(word) > en) then
                         call abort('parse_formula: element symbol too long: '//trim(word))
                     end if
-                    f%elements(n) = word
-                    f%coefficients(n) = scanner%read_real()
+                    f%elements(i) = word
+                    f%coefficients(i) = scanner%read_real()
+                    n = i
                 case default
                     exit  ! Start of new keyword
             end select


### PR DESCRIPTION
## Summary
Uninitialized memory could be read for cases that have specified reactant formulas in the input file with the legacy interface. The problem is due to an error in inputs.f90 / parse_formula function, where the reactant formula is resized to the intended length + 1.

This PR addresses Issue #26 

## Changes
Reduce the size of the formula%elements and coefficients arrays by one when the last pass through the read loop did not result in addition of a new element

## Testing
GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
ifx (IFX) 2025.3.2 20260112 on ubuntu
Intel(R) Fortran Compiler for applications running on Intel(R) 64, Version 2025.3.2 Build 20260112 Win 11

Testing was conducted on two different Windows 11 machines, one of which experienced the failure described in Issue #26 prior to this fix.

Passes ctest and pytest suites on Windows with ifx, ubuntu with gfortran, ifx
test/main_interface/test_main.py produces same result as prior to change (13/14)

## Compatibility / Numerical behavior
- [ X] No expected changes to numerical results
- [ ] Expected changes (explain and provide validation)
