### PR TITLE
Check if pcp_schedule is allocated before assigning pi_p values

### DIFF
--- a/source/main.f90
+++ b/source/main.f90
@@ -398,7 +398,7 @@ contains
         end if
 
         ! Get the rocket variables
-        pi_p = prob%problem%pcp_schedule%values
+        if (allocated(prob%problem%pcp_schedule)) pi_p = prob%problem%pcp_schedule%values
         if (allocated(prob%problem%subar_schedule)) subar = prob%problem%subar_schedule%values
         if (allocated(prob%problem%supar_schedule)) supar = prob%problem%supar_schedule%values
         if (allocated(prob%problem%mdot)) mdot = prob%problem%mdot


### PR DESCRIPTION
## Summary
Running a rocket problem with legacy style input files would create a sigsegv if a pip value was not explicitly assigned. This has been fixed in this branch
Fixes #30 
## Changes
rocket problem checks if pcp_schedule is allocated before assigning to pi_p
## Testing
test_results appended
Tested on a windows installation compiled with MinGW64-

## Compatibility / Numerical behavior
- [x] No expected changes to numerical results
- [ ] Expected changes (explain and provide validation)
[test_results.csv](https://github.com/user-attachments/files/25369546/test_results.csv)

Some numerical results are slightly different (relative error ~1e-4) but I would attribute this to a different building environment, I can't see how this change would affect that
