### PR TITLE
Fixed detonation wave upstream enthalpy calc and legacy interface upstream MW

### DIFF
--- a/source/detonation.f90
+++ b/source/detonation.f90
@@ -121,8 +121,7 @@ contains
         soln%T1 = t1
         soln%eq_soln%T = t1
         soln%P1 = p1
-        soln%H1 = (self%eq_solver%reactants%calc_enthalpy(weights, t1) - &
-            self%eq_solver%reactants%calc_enthalpy(weights, 298.15d0))/1.d3
+        soln%H1 = (self%eq_solver%reactants%calc_enthalpy(weights, t1))/1.d3
         cp = self%eq_solver%reactants%calc_frozen_cp(weights, t1)
         wm = sum(weights)/sum(self%eq_solver%reactants%moles_from_weights(weights))
         soln%M1 = wm

--- a/source/main.f90
+++ b/source/main.f90
@@ -1264,7 +1264,7 @@ contains
                 write(ioout, '(A, 14F9.4)') ' P1, bar          ', ((solutions(i, j, k)%P1,       j=1,n), i=1,m)
                 write(ioout, '(A, 14F9.2)') ' T1, K            ', ((solutions(i, j, k)%T1,       j=1,n), i=1,m)
                 write(ioout, '(A, 14F9.2)') ' H1, kJ/kg        ', ((solutions(i, j, k)%H1,       j=1,n), i=1,m)
-                write(ioout, '(A, 14F9.3)') ' M1, (1/n)        ', ((1.0/solutions(i, j, k)%M1,   j=1,n), i=1,m)
+                write(ioout, '(A, 14F9.3)') ' M1, (1/n)        ', ((solutions(i, j, k)%M1,       j=1,n), i=1,m)
                 write(ioout, '(A, 14F9.4)') ' Gamma1           ', ((solutions(i, j, k)%gamma1,   j=1,n), i=1,m)
                 write(ioout, '(A, 14F9.3)') ' Son. Vel.1, m/s  ', ((solutions(i, j, k)%v_sonic1, j=1,n), i=1,m)
 


### PR DESCRIPTION
## Summary
The upstream enthalpy for detonation problems was incorrect when the mixture contains species whose heat of formation is not defined as zero at 298.15 K. This resulted in an incorrect CJ speed.

In addition, the upstream molecular weight was printed as its inverse on the legacy interface.

This PR addresses Issue #31 

## Changes
Enthalpy of pre-detonation mixture was originally computed as h(T) - h(298.15 K), which resulted in an incorrect mixture enthalpy for cases where species with non-zero heat of formation were present (e.g., hydrocarbon fuels). The calculation was corrected to not subtract h(298.15 K).

Removed calculation that inverted the upstream mixture molecular weight when using the legacy interface.

## Testing
Passed integration harness, pytest on Win 11 w/ifx compiler set. 
Sample ethylene-O2 detonation problem from Issue #31  now produces results consistent with CEA2 and the CJ speed is as expected.

## Compatibility / Numerical behavior
- [ ] No expected changes to numerical results
- [ X] Expected changes (explain and provide validation)
Upstream enthalpy H1, molecular weight M1, and detonation velocity now match CEA2 results for the sample ethylene - O2 problem. CJ speed is now within 0.03% of an independent calculation using Cantera.
