### PR TITLE
resolve duplicate names for release artifact

### DIFF
--- a/.github/workflows/basic_build.yml
+++ b/.github/workflows/basic_build.yml
@@ -335,16 +335,27 @@ jobs:
           path: release-dist
           merge-multiple: false
 
+      - name: Prepare release assets (unique names)
+        run: |
+          mkdir -p release-assets
+          while IFS= read -r -d '' file; do
+            rel="${file#release-dist/}"
+            artifact="${rel%%/*}"
+            subpath="${rel#*/}"
+            asset_name="${artifact}__${subpath//\//__}"
+            cp "${file}" "release-assets/${asset_name}"
+          done < <(find release-dist -type f -print0)
+
       - name: Generate SHA256 checksums
         run: |
-          cd release-dist
-          find . -type f -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS.txt
+          cd release-assets
+          find . -maxdepth 1 -type f -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS.txt
           cat SHA256SUMS.txt
 
       - name: Publish GitHub release assets
         uses: softprops/action-gh-release@v2
         with:
-          files: release-dist/**
+          files: release-assets/*
           generate_release_notes: true
 
   bindc:


### PR DESCRIPTION
## Summary
Implemented a fix in the release workflow to avoid GitHub asset-name collisions during tag releases.

## Changes
Updated `basic_build.yml` in the `release-artifacts` job:
1. Added a new step to stage files into release-assets/ with unique names:
  - format: `<artifact-name>__<original-path-with-__separators>`
2. Changed checksum generation to run over `release-assets/` (flat unique filenames).
3. Changed release upload glob from `release-dist/**` to `release-assets/*`.

## Testing
- Not run - CI impacts only.

## Compatibility / Numerical behavior
- [x] No expected changes to numerical results
- [ ] Expected changes (explain and provide validation)
