### PR TITLE
added multiline output keyword support; propogated ions into product …

### DIFF
--- a/source/input.f90
+++ b/source/input.f90
@@ -250,6 +250,11 @@ contains
                 line = adjustl(line)
                 if (is_empty(line)) cycle
                 if (is_keyword(line)) then
+                    if (dsname == 'outp' .and. line(1:4) == 'outp') then
+                        ! Legacy behavior allows repeated output datasets; merge them.
+                        buffer = buffer // ' ' // trim(line)
+                        cycle
+                    end if
                     backspace(fin)
                     exit
                 else

--- a/source/input_test.pf
+++ b/source/input_test.pf
@@ -121,6 +121,19 @@ contains
     end subroutine
 
     @test
+    subroutine test_parse_outp_repeated_dataset_keywords
+        type(OutputDataset) :: outp
+
+        outp = parse_outp('outp short outp massf outp siunits outp trace=1e-8 outp transport')
+
+        @assertEqual(.true., outp%mass_fractions)
+        @assertEqual(.true., outp%transport)
+        @assertTrue(allocated(outp%trace))
+        @assertEqual(1.0d-8, outp%trace)
+        @assertEqual(.true., outp%siunit)
+    end subroutine
+
+    @test
     subroutine test_parse_reac_custom_species
         type(ReactantInput), allocatable :: reac(:)
         allocate(reac(0))

--- a/source/main.f90
+++ b/source/main.f90
@@ -266,7 +266,7 @@ contains
         else
             product_names = reactants%get_products(thermo)
         end if
-        products = Mixture(thermo, product_names)
+        products = Mixture(thermo, product_names, ions=prob%problem%include_ions)
 
         ! Get the loop sizes
         num_state1 = 1
@@ -535,7 +535,7 @@ contains
         else
             product_names = reactants%get_products(thermo)
         end if
-        products = Mixture(thermo, product_names)
+        products = Mixture(thermo, product_names, ions=prob%problem%include_ions)
 
         ! Get the problem flags
         if (prob%problem%shk_incident) then
@@ -767,7 +767,7 @@ contains
         else
             product_names = reactants%get_products(thermo)
         end if
-        products = Mixture(thermo, product_names)
+        products = Mixture(thermo, product_names, ions=prob%problem%include_ions)
 
         ! Get the problem flags
         if (prob%problem%frozen) then


### PR DESCRIPTION
## Summary
Fix two legacy CLI compatibility issues affecting CEARUN-style inputs:

1. Prevent `EqSolver_init` element-list mismatch crashes for ionized legacy problems by ensuring reactants/products are initialized with consistent `ions` handling.
2. Restore legacy cumulative parsing behavior for repeated `output` datasets (multiple `output ...` lines in one problem).

## Changes
- Updated product mixture construction to propagate `ions=prob%problem%include_ions` in:
  - `run_thermo_problem` (`source/main.f90`)
  - `run_shock_problem` (`source/main.f90`)
  - `run_deton_problem` (`source/main.f90`)
- Updated input parser dataset read loop in `source/input.f90`:
  - When currently parsing an `outp` dataset, consecutive `outp` keyword lines are merged into the same buffer instead of starting a new dataset that overwrites prior output options.
  - This matches legacy `cea2.f` behavior for repeated `output` directives.
- Added parser regression coverage in `source/input_test.pf`:
  - New test `test_parse_outp_repeated_dataset_keywords`
  - Verifies repeated `outp` tokens cumulatively set `mass_fractions`, `transport`, `trace`, and preserve `siunit`.

## Testing
- Manual legacy CLI runs in `build-dev-ub-hunt/source`:
  - `./cea cearun -t ../../data/thermo.lib -r ../../data/trans.lib`
  - `./cea example1 -t ../../data/thermo.lib -r ../../data/trans.lib`
- Output/reference check:
  - `diff -u cearun-ref.out cearun.out` (verified crash is resolved and expected output sections are present; formatting/style differences remain vs legacy reference formatting)
- Full tests:
  - `cd build-dev-ub-hunt && ctest --output-on-failure` (12/12 passed)

## Compatibility / Numerical behavior
- [ ] No expected changes to numerical results
- [x] Expected changes (explain and provide validation)

Expected behavior change: ionized legacy CLI cases that previously aborted with  
`CRITICAL: eqsolver_init: Element lists for products and reactants must match.`  
now run to completion. No solver algorithm changes were introduced; updates are limited to initialization consistency and legacy-compatible `output` parsing.