### PR TITLE
write input file contents at the top of each output per-problem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable user-visible changes to this project are documented here.
 ## [Unreleased]
 
 ### Changed
+- Legacy CLI `.out` files now echo each problem’s original input block before the corresponding equilibrium, rocket, shock, or detonation output section.
 
 ### Fixed
 

--- a/source/input.f90
+++ b/source/input.f90
@@ -142,6 +142,8 @@ module cea_input
             !! Exact species to include in product mixture
         character(sn), allocatable :: insert(:)
             !! Species to insert into product mixture
+        character(:), allocatable :: raw_input
+            !! Original input text for this problem block
     end type
 
 contains
@@ -171,8 +173,7 @@ contains
             do
                 read(fin, '(a)', iostat=ierr) line
                 if (ierr /= 0) exit
-                line = adjustl(line)
-                if (.not. is_empty(line)) then
+                if (len_trim(line) > 0) then
                     backspace(fin)
                     exit
                 end if
@@ -205,17 +206,18 @@ contains
         type(ProblemDB), intent(out) :: problem
         integer, intent(out) :: ierr
 
-        character(512) :: line
+        character(512) :: line, raw_line
         character(:), allocatable :: buffer, dsname
-        logical :: has_data, has_prob, has_reac
+        logical :: has_data, has_prob, has_reac, capture_started
 
         has_data = .false.
         has_prob = .false.
         has_reac = .false.
+        capture_started = .false.
         do
 
             ! Get next good line of input
-            read(fin, '(a)', iostat=ierr) line
+            read(fin, '(a)', iostat=ierr) raw_line
             if (ierr /= 0) then
                 if (has_data) then
                     call abort('Problem is missing end keyword.')
@@ -224,7 +226,18 @@ contains
                     return
                 end if
             end if
-            line = adjustl(line)
+            line = adjustl(raw_line)
+            if (len_trim(raw_line) > 0) then
+                if (.not. capture_started) then
+                    problem%raw_input = trim(raw_line)
+                    capture_started = .true.
+                else
+                    problem%raw_input = problem%raw_input // new_line('a') // trim(raw_line)
+                end if
+            else if (capture_started) then
+                problem%raw_input = problem%raw_input // new_line('a')
+            end if
+
             if (is_empty(line)) cycle
             if (startswith(line,'end')) then
                 call assert(has_prob, 'Problem is missing prob dataset.')
@@ -245,19 +258,28 @@ contains
             ! Read until next keyword, saving input
             buffer = trim(line)
             do
-                read(fin, '(A)', iostat=ierr) line
+                read(fin, '(A)', iostat=ierr) raw_line
                 if (ierr /= 0) call abort('Problem has incomplete dataset: '//dsname)
-                line = adjustl(line)
-                if (is_empty(line)) cycle
+                line = adjustl(raw_line)
+                if (len_trim(raw_line) == 0) then
+                    problem%raw_input = problem%raw_input // new_line('a')
+                    cycle
+                end if
+                if (is_empty(line)) then
+                    problem%raw_input = problem%raw_input // new_line('a') // trim(raw_line)
+                    cycle
+                end if
                 if (is_keyword(line)) then
                     if (dsname == 'outp' .and. line(1:4) == 'outp') then
                         ! Legacy behavior allows repeated output datasets; merge them.
+                        problem%raw_input = problem%raw_input // new_line('a') // trim(raw_line)
                         buffer = buffer // ' ' // trim(line)
                         cycle
                     end if
                     backspace(fin)
                     exit
                 else
+                    problem%raw_input = problem%raw_input // new_line('a') // trim(raw_line)
                     buffer = buffer // ' ' // trim(line)
                 end if
             end do

--- a/source/main.f90
+++ b/source/main.f90
@@ -90,6 +90,7 @@ program cea
 
         ! Setup
         prob = problems(n)
+        call write_problem_input(1, prob, n > 1)
 
         select case(prob%problem%type)
             case ("tp", "hp", "sp", "tv", "uv", "sv")
@@ -201,6 +202,35 @@ contains
         end if
 
         return
+    end subroutine
+
+    subroutine write_problem_input(ioout, prob, separate_from_previous)
+        integer, intent(in) :: ioout
+        type(ProblemDB), intent(in) :: prob
+        logical, intent(in) :: separate_from_previous
+
+        integer :: line_start, line_end
+        character(:), allocatable :: line
+
+        if (.not. allocated(prob%raw_input)) return
+
+        if (separate_from_previous) write(ioout, '(A)') ""
+        write(ioout, '(A)') ""
+
+        line_start = 1
+        do while (line_start <= len(prob%raw_input))
+            line_end = index(prob%raw_input(line_start:), new_line('a'))
+            if (line_end == 0) then
+                line = prob%raw_input(line_start:)
+                line_start = len(prob%raw_input) + 1
+            else
+                line = prob%raw_input(line_start:line_start + line_end - 2)
+                line_start = line_start + line_end
+            end if
+            write(ioout, '(A)') ' ' // line
+        end do
+
+        write(ioout, '(A)') ""
     end subroutine
 
     subroutine display_help


### PR DESCRIPTION
## Summary
Echo each problem's original input block at the top of the corresponding legacy CLI `.out` section, independent of problem type.

## Changes
- Added `ProblemDB%raw_input` to preserve the original per-problem input text during parsing.
- Updated `read_problem` to capture each problem block's raw input while keeping existing parsing behavior unchanged.
- Added a `main.f90` output helper that writes the stored input block before equilibrium, rocket, shock, and detonation output sections.

## Testing
- Ran focused CLI checks:
  - `./build-dev/source/cea test/main_interface/example1`
  - `./build-dev/source/cea test/main_interface/example8`
  - `./build-dev/source/cea test/main_interface/example7`
  - `./build-dev/source/cea test/main_interface/example6`
- Ran regression script: `python test/main_interface/test_main.py`
  - Result: `13/14` tests passed; existing `example11` mismatch remained unchanged

## Compatibility / Numerical behavior
- [x] No expected changes to numerical results
- [ ] Expected changes (explain and provide validation)
