### PR TITLE
Bug fix for input token parsing

### DIFF
--- a/source/input.f90
+++ b/source/input.f90
@@ -612,7 +612,7 @@ contains
         character(:), allocatable :: tok
         integer :: l
 
-        tok = trim(token)
+        tok = to_upper(trim(token))
         l = len_trim(tok)
         if (l < 1 .or. l > 2) then
             tf = .false.
@@ -623,7 +623,7 @@ contains
             return
         end if
         if (l == 2) then
-            tf = (tok(2:2) >= 'a' .and. tok(2:2) <= 'z')
+            tf = (tok(2:2) >= 'A' .and. tok(2:2) <= 'Z')
         else
             tf = .true.
         end if
@@ -791,15 +791,17 @@ contains
         integer :: i, n, ierr
         real(dp) :: val
         character(:), allocatable :: word
+        character(:), allocatable :: element
 
         allocate(f%elements(max_values))
         allocate(f%coefficients(max_values))
 
         n = 1
-        if (len_trim(token) > en) then
+        element = to_upper(trim(token))
+        if (len_trim(element) > en) then
             call abort('parse_formula: element symbol too long: '//trim(token))
         end if
-        f%elements(n) = token
+        f%elements(n) = element
         f%coefficients(n) = 1.0d0
         val = scanner%peek_real(ierr)
         if (ierr == 0) f%coefficients(n) = scanner%read_real(ierr)
@@ -807,20 +809,17 @@ contains
         do i = 2,size(f%elements)
             word = scanner%peek_word(ierr)
             if (ierr /= 0) exit  ! Buffer empty
-            select case(word(1:1))
-                case('A':'Z')
-                    word = scanner%read_word()
-                    if (len_trim(word) > en) then
-                        call abort('parse_formula: element symbol too long: '//trim(word))
-                    end if
-                    f%elements(i) = word
-                    f%coefficients(i) = 1.0d0
-                    val = scanner%peek_real(ierr)
-                    if (ierr == 0) f%coefficients(i) = scanner%read_real(ierr)
-                    n = i
-                case default
-                    exit  ! Start of new keyword
-            end select
+            if (.not. is_formula_element_token(word)) exit  ! Start of new keyword
+            word = scanner%read_word()
+            word = to_upper(trim(word))
+            if (len_trim(word) > en) then
+                call abort('parse_formula: element symbol too long: '//trim(word))
+            end if
+            f%elements(i) = word
+            f%coefficients(i) = 1.0d0
+            val = scanner%peek_real(ierr)
+            if (ierr == 0) f%coefficients(i) = scanner%read_real(ierr)
+            n = i
         end do
 
         f%elements = f%elements(:n)
@@ -959,6 +958,20 @@ contains
             code = iachar(out(i:i))
             if (code >= iachar('A') .and. code <= iachar('Z')) then
                 out(i:i) = achar(code + 32)
+            end if
+        end do
+    end function
+
+    function to_upper(txt) result(out)
+        character(*), intent(in) :: txt
+        character(:), allocatable :: out
+        integer :: i, code
+
+        out = txt
+        do i = 1, len(out)
+            code = iachar(out(i:i))
+            if (code >= iachar('a') .and. code <= iachar('z')) then
+                out(i:i) = achar(code - 32)
             end if
         end do
     end function

--- a/test/main_interface/example15.inp
+++ b/test/main_interface/example15.inp
@@ -1,17 +1,24 @@
- problem case=Prop_P120C_all rocket eq
+#  EXAMPLE 15:
+#     (a)  Rocket problem at assigned chamber pressure (rocket eq).
+#     (b)  Reactants are provided as named mixtures with exploded formulas.
+#     (c)  Amounts are specified in weight percent.
+#     (d)  Chamber pressure is p(bar)=5.00.
 
+# 'problem' dataset:
+problem  case=15  rocket  eq  p(bar)=5.00
 
-     p(bar)= 5.00
+# 'reactants' dataset:
+reac
+   name=A  wt%=67.000              H 4.0000  O 4.0000  N 1.0000  CL 1.0000  h,cal=-70690.0
+   name=B  wt%=20.000                                               AL 1.0000  h,cal=0.0
+   name=C  wt%=13.000  C 7.2913  H 11.0192  O 0.0823                          h,cal=500.0
 
+# A = Ammonium Perchlorate
+# B = Aluminum
+# C = HTPB RV4
 
- reac
-      name= A   wt%=67.000              H  4.0000  O  4.0000  N  1.0000  CL 1.0000  h,cal= -70690.0
-      name= B   wt%=20.000                                               AL 1.0000  h,cal=      0.0
-      name= C   wt%=13.000   C  7.2913  H 11.0192  O  0.0823                        h,cal=    500.0
+# 'output' dataset:
+output  si  massf  trans
 
-#A = Ammonium Perchlorate
-#B = Aluminum
-#C = HTPB RV4
-
- output si massf trans
- end
+# 'end' dataset:
+end

--- a/test/main_interface/example15.inp
+++ b/test/main_interface/example15.inp
@@ -1,0 +1,17 @@
+ problem case=Prop_P120C_all rocket eq
+
+
+     p(bar)= 5.00
+
+
+ reac
+      name= A   wt%=67.000              H  4.0000  O  4.0000  N  1.0000  CL 1.0000  h,cal= -70690.0
+      name= B   wt%=20.000                                               AL 1.0000  h,cal=      0.0
+      name= C   wt%=13.000   C  7.2913  H 11.0192  O  0.0823                        h,cal=    500.0
+
+#A = Ammonium Perchlorate
+#B = Aluminum
+#C = HTPB RV4
+
+ output si massf trans
+ end

--- a/test/main_interface/reference_output/example15.out
+++ b/test/main_interface/reference_output/example15.out
@@ -1,0 +1,153 @@
+
+  problem case=Prop_P120C_all rocket eq
+ 
+ 
+      p(bar)= 5.00
+ 
+ 
+  reac
+       name= A   wt%=67.000              H  4.0000  O  4.0000  N  1.0000  CL 1.0000  h,cal= -70690.0
+       name= B   wt%=20.000                                               AL 1.0000  h,cal=      0.0
+       name= C   wt%=13.000   C  7.2913  H 11.0192  O  0.0823                        h,cal=    500.0
+ 
+ #A = Ammonium Perchlorate
+ #B = Aluminum
+ #C = HTPB RV4
+ 
+  output si massf trans
+  end
+
+THEORETICAL ROCKET PERFORMANCE ASSUMING EQUILIBRIUM
+COMPOSITION DURING EXPANSION FROM INFINITE AREA COMBUSTOR
+ 
+Pc =   5.00 bar
+ 
+ 
+ 
+            REACTANT     MOLES    ENERGY      TEMP
+                                  KJ/MOL         K
+     A                  67.000       0.000      0.00
+     B                  20.000       0.000      0.00
+     C                  13.000       0.000      0.00
+ 
+O/F =    0.00000    % Fuel =   0.00000    r, Eq. Ratio =  0.00000    phi, Eq. Ratio =  0.00000
+ 
+
+                        CHAMBER       THROAT
+ Pinf/P                  1.0000
+ P, bar                  5.0000
+ T, K                   3216.88
+ Density, kg/m^3      0.5168E+0
+ H, kJ/kg             -1683.938
+ U, kJ/kg             -2651.508
+ G, kJ/kg             -34425.54
+ S, kJ/kg-K              10.178
+ 
+ M, (1/n)               27.6433
+ (dln(V)/dln(P))t       -1.0324
+ (dln(V)/dln(T))p        1.6343
+ Cp, kJ/(kg-K)           5.8857
+ Gamma_s                 1.1162
+ Son. Vel., m/s         1039.22
+ Mach                    0.0000
+ 
+ TRANSPORT PROPERTIES (GASES ONLY)
+    CONDUCTIVITY IN UNITS OF MILLICALORIES/(CM)(K)(SEC)
+ 
+  Visc, Millipois        0.9492
+ 
+ WITH EQUILIBRIUM REACTIONS
+  Cp, kJ/(kg-K)          5.8857
+  Conductivity          19.9475
+  Prandtl Number         0.2718
+ 
+ WITH FROZEN REACTIONS
+  Cp, kJ/(kg-K)          2.0296
+  Conductivity           4.1269
+  Prandtl Number         0.4668
+ 
+ 
+MASS FRACTIONS
+ 
+ AL                    7.426E-4
+ AL(OH)2               2.002E-4
+ AL(OH)2CL             1.825E-4
+ AL(OH)3               3.187E-5
+ AL2O                  9.853E-4
+ AL2O2                 2.334E-4
+ ALCL                  0.036594
+ ALCL2                 0.001478
+ ALCL3                 2.896E-4
+ ALH                   7.888E-5
+ ALHCL                 4.478E-5
+ ALHCL2                5.258E-5
+ ALO                   0.001087
+ ALOCL                 0.002023
+ ALOH                  0.015250
+ ALOHCL                0.001249
+ ALOHCL2               9.100E-4
+ CL                    0.023734
+ CL2                   2.405E-5
+ CO                    0.257446
+ CO2                   0.012651
+ H                     0.002744
+ H2                    0.023811
+ H2O                   0.052026
+ HALO2                 3.132E-5
+ HCL                   0.158546
+ HCO                   6.212E-6
+ N                     3.259E-6
+ N2                    0.079662
+ NO                    4.414E-4
+ O                     5.669E-4
+ O2                    1.082E-4
+ OH                    0.004731
+ AL2O3(L)              0.321993
+
+PRODUCTS WHICH WERE CONSIDERED BUT WHOSE MASS FRACTIONS
+WERE LESS THAN 5.000000E-06 FOR ALL ASSIGNED CONDITIONS
+
+ (CH3COOH)2      (HCOOH)2        AL2             AL2C2           AL2CL6         
+ AL2O3           ALC             ALC2            ALH2            ALH2CL         
+ ALH3            ALN             ALO2            ALOCL2          C              
+ C10H21,n-decyl  C10H8,naphthale C12H10,biphenyl C12H9,o-bipheny C2             
+ C2CL            C2CL2           C2CL3           C2CL4           C2CL6          
+ C2H             C2H2,acetylene  C2H2,vinylidene C2H2CL2         C2H3,vinyl     
+ C2H3CL          C2H4            C2H4O,ethylen-o C2H5            C2H5OH         
+ C2H6            C2HCL           C2HCL3          C2N2            C2O            
+ C3              C3H3,1-propynl  C3H3,2-propynl  C3H4,allene     C3H4,cyclo-    
+ C3H4,propyne    C3H5,allyl      C3H6,cyclo-     C3H6,propylene  C3H6O,acetone  
+ C3H6O,propanal  C3H6O,propylox  C3H7,i-propyl   C3H7,n-propyl   C3H8           
+ C3H8O,1propanol C3H8O,2propanol C3O2            C4              C4H10,isobutane
+ C4H10,n-butane  C4H2,butadiyne  C4H4,1,3-cyclo- C4H6,1butyne    C4H6,2butyne   
+ C4H6,butadiene  C4H6,cyclo-     C4H8,1-butene   C4H8,cis2-buten C4H8,cyclo-    
+ C4H8,isobutene  C4H8,tr2-butene C4H9,i-butyl    C4H9,n-butyl    C4H9,s-butyl   
+ C4H9,t-butyl    C4N2            C5              C5H10,1-pentene C5H10,cyclo-   
+ C5H11,pentyl    C5H11,t-pentyl  C5H12,i-pentane C5H12,n-pentane C5H6,1,3cyclo- 
+ C5H8,cyclo-     C6H10,cyclo-    C6H12,1-hexene  C6H12,cyclo-    C6H13,n-hexyl  
+ C6H14,n-hexane  C6H2            C6H5,phenyl     C6H5O,phenoxy   C6H5OH,phenol  
+ C6H6            C7H14,1-heptene C7H15,n-heptyl  C7H16,2-methylh C7H16,n-heptane
+ C7H7,benzyl     C7H8            C7H8O,cresol-mx C8H10,ethylbenz C8H16,1-octene 
+ C8H17,n-octyl   C8H18,isooctane C8H18,n-octane  C8H8,styrene    C9H19,n-nonyl  
+ CCL             CCL2            CCL3            CCL4            CCN            
+ CH              CH2             CH2CL           CH2CL-COOH      CH2CL2         
+ CH2CO,ketene    CH2OH           CH3             CH3C(CH3)2CH3   CH3CHO,ethanal 
+ CH3CL           CH3CN           CH3CO,acetyl    CH3COOH         CH3N2CH3       
+ CH3O            CH3O2CH3        CH3OCH3         CH3OH           CH3OOH         
+ CH4             CHCL            CHCL2           CHCL3           CL2O           
+ CLCN            CLO             CLO2            CN              CNC            
+ CNCOCN          CNN             COCL            COCL2           COHCL          
+ COOH            H2O2            HALO            HCCN            HCCO           
+ HCHO,formaldehy HCN             HCOOH           HNC             HNCO           
+ HNO             HNO2            HNO3            HO(CO)2OH       HO2            
+ HOCL            N2H2            N2H4            N2O             N2O3           
+ N2O4            N2O5            N3              N3H             NCN            
+ NCO             NH              NH2             NH2NO2          NH2OH          
+ NH3             NO2             NO2CL           NO3             NOCL           
+ O(CH)2O         O3              OCCN            OHCH2COOH       AL(L)          
+ AL(OH)3(a)      AL(cr)          AL2O3(a)        AL4C3(cr)       ALCL3(L)       
+ ALCL3(cr)       ALH3(a)         ALN(L)          ALN(cr)         C(gr)          
+ H2O(L)          H2O(cr)         NH4CL(II)       NH4CL(III)     
+
+NOTE. WEIGHT FRACTION OF FUEL IN TOTAL FUELS AND OF OXIDANT IN TOTAL OXIDANTS
+

--- a/test/main_interface/reference_output/example15.out
+++ b/test/main_interface/reference_output/example15.out
@@ -1,21 +1,28 @@
 
-  problem case=Prop_P120C_all rocket eq
+ #  EXAMPLE 15:
+ #     (a)  Rocket problem at assigned chamber pressure (rocket eq).
+ #     (b)  Reactants are provided as named mixtures with exploded formulas.
+ #     (c)  Amounts are specified in weight percent.
+ #     (d)  Chamber pressure is p(bar)=5.00.
  
+ # 'problem' dataset:
+ problem  case=15  rocket  eq  p(bar)=5.00
  
-      p(bar)= 5.00
+ # 'reactants' dataset:
+ reac
+    name=A  wt%=67.000              H 4.0000  O 4.0000  N 1.0000  CL 1.0000  h,cal=-70690.0
+    name=B  wt%=20.000                                               AL 1.0000  h,cal=0.0
+    name=C  wt%=13.000  C 7.2913  H 11.0192  O 0.0823                          h,cal=500.0
  
+ # A = Ammonium Perchlorate
+ # B = Aluminum
+ # C = HTPB RV4
  
-  reac
-       name= A   wt%=67.000              H  4.0000  O  4.0000  N  1.0000  CL 1.0000  h,cal= -70690.0
-       name= B   wt%=20.000                                               AL 1.0000  h,cal=      0.0
-       name= C   wt%=13.000   C  7.2913  H 11.0192  O  0.0823                        h,cal=    500.0
+ # 'output' dataset:
+ output  si  massf  trans
  
- #A = Ammonium Perchlorate
- #B = Aluminum
- #C = HTPB RV4
- 
-  output si massf trans
-  end
+ # 'end' dataset:
+ end
 
 THEORETICAL ROCKET PERFORMANCE ASSUMING EQUILIBRIUM
 COMPOSITION DURING EXPANSION FROM INFINITE AREA COMBUSTOR

--- a/test/main_interface/test_main.py
+++ b/test/main_interface/test_main.py
@@ -18,7 +18,7 @@ rtol = 1e-2  # Relative acceptance tolerance for all values
 round_vals = True  # Attempt to round the test values to the precision of the reference value
 test_names = [
     "example1", "example2", "example3", "example4", "example5", "example14",   # Equilibrium problems
-    "example8", "example9", "example10", "example11", "example12", "example13", # Rocket problems
+    "example8", "example9", "example10", "example11", "example12", "example13", "example15", # Rocket problems
     "example7",  # Shock problem
     "example6"   # Deton problem
     ]


### PR DESCRIPTION
## Summary

This PR fixes a parser robustness issue in the main input path where mixed/lowercase element tokens in reactant definitions could break parsing. It also adds a regression case from a real failing input and aligns that new test file with the established test style.

## What changed

- Input parser robustness update in source/input.f90:
  - Normalises relevant tokens to uppercase before element-token checks and formula parsing.
- New regression case added to the main-interface suite.

## Why

Reading a rocket input with named reactants and exploded formulas (mixed-case element notation) was failing, but working properly with the old legacy CEA program.
The parser change ensures backward-compatible for legacy-style inputs.

## Numerical/behavior impact

- No solver algorithm changes.
- No changes to tolerances, convergence logic, or numerical method flow.
- No edits to thermodynamic/transport database files.

## Validation performed

- New case, previously failing, runs successfully.
- Other regression assets were successfully tested.