### PR TITLE
Fixed units default for reactant energy / enthalpy in legacy input file parser

### DIFF
--- a/source/input.f90
+++ b/source/input.f90
@@ -926,12 +926,12 @@ contains
                     if (substring(txt,'psi')) units = 'psi'
                     if (substring(txt,'mmh')) units = 'mmhg'
                 case ('h')
-                    units = 'j'
+                    units = 'j/mole'
                     if (substring(txt,'kj')) units = 'kj/mole'
                     if (substring(txt,'kc')) units = 'kcal/mole'
                     if (substring(txt, 'c')) units = 'cal/mole'
                 case ('u')
-                    units = 'j'
+                    units = 'j/mole'
                     if (substring(txt,'kj')) units = 'kj/mole'
                     if (substring(txt,'kc')) units = 'kcal/mole'
                     if (substring(txt, 'c')) units = 'cal/mole'


### PR DESCRIPTION

## Summary
Fix for Issue #86. This is a simple change that address a cosmetic issue (inappropriate error output message)

## Changes
changed default energy and enthalpy units in input.f90 
WAS: 'j'
IS: 'j/mole'

## Testing
passes test_main.py, ctest, and pytest 100%
now runs the example case provided in Issue #86 without generating an error output. Results still match expected:
```
iff example5.out example5mod_J.out
21c21
<                            h,cal=-2999.082 t(k)=298.15
---
>                            h,j=-12548.1590880 t(k)=298.15
```
Also tested with h=-12548.159088 (no units) to verify default units are j/mole per RP-1311.

## Compatibility / Numerical behavior
- [ X] No expected changes to numerical results
- [ ] Expected changes (explain and provide validation)
