### PR TITLE
Ensure output text stating conductivity units is mW/cm-K on legacy interface when siunits is true

### DIFF
--- a/source/main.f90
+++ b/source/main.f90
@@ -1721,7 +1721,11 @@ contains
             if (prob%output%transport) then
                 write(ioout, *) ""
                 write(ioout, '(A)') " TRANSPORT PROPERTIES (GASES ONLY)"
-                write(ioout, '(A)') "    CONDUCTIVITY IN UNITS OF MILLICALORIES/(CM)(K)(SEC)"
+                if (prob%output%siunit) then
+                    write(ioout, '(A)') "    CONDUCTIVITY IN UNITS OF MILLIWATTS/(CM)(K)"
+                else
+                    write(ioout, '(A)') "    CONDUCTIVITY IN UNITS OF MILLICALORIES/(CM)(K)(SEC)"
+                end if
                 write(ioout, *) ""
 
                 ! Viscosity
@@ -2354,7 +2358,11 @@ contains
             if (prob%output%transport) then
                 write(ioout, *) ""
                 write(ioout, '(A)') " TRANSPORT PROPERTIES (GASES ONLY)"
-                write(ioout, '(A)') "    CONDUCTIVITY IN UNITS OF MILLICALORIES/(CM)(K)(SEC)"
+                if (prob%output%siunit) then
+                    write(ioout, '(A)') "    CONDUCTIVITY IN UNITS OF MILLIWATTS/(CM)(K)"
+                else
+                    write(ioout, '(A)') "    CONDUCTIVITY IN UNITS OF MILLICALORIES/(CM)(K)(SEC)"
+                end if
                 write(ioout, *) ""
 
                 ! Viscosity
@@ -2893,7 +2901,11 @@ contains
                     if (prob%output%transport) then
                         write(ioout, *) ""
                         write(ioout, '(A)') " TRANSPORT PROPERTIES (GASES ONLY)"
-                        write(ioout, '(A)') "    CONDUCTIVITY IN UNITS OF MILLICALORIES/(CM)(K)(SEC)"
+                        if (prob%output%siunit) then
+                            write(ioout, '(A)') "    CONDUCTIVITY IN UNITS OF MILLIWATTS/(CM)(K)"
+                        else
+                            write(ioout, '(A)') "    CONDUCTIVITY IN UNITS OF MILLICALORIES/(CM)(K)(SEC)"
+                        end if
                         write(ioout, *) ""
 
                         ! Viscosity
@@ -3341,7 +3353,11 @@ contains
                         if (prob%output%transport) then
                             write(ioout, *) ""
                             write(ioout, '(A)') " TRANSPORT PROPERTIES (GASES ONLY)"
-                            write(ioout, '(A)') "    CONDUCTIVITY IN UNITS OF MILLICALORIES/(CM)(K)(SEC)"
+                            if (prob%output%siunit) then
+                                write(ioout, '(A)') "   CONDUCTIVITY IN UNITS OF MILLIWATTS/(CM)(K)"
+                            else
+                                write(ioout, '(A)') "   CONDUCTIVITY IN UNITS OF MILLICALORIES/(CM)(K)(SEC)"
+                            end if
                             write(ioout, *) ""
 
                             ! Viscosity


### PR DESCRIPTION
## Summary
Addresses Issue #88 wrong units described in output file for thermal conductivity in detonation, equilibrium, and rocket problems when siunits is true.

## Changes
Added test for selected units system and appropriate text output depending on whether calories or SI units are selected. 

## Testing
- ctest, legacy interface test, pytest all pass 100%. Example detonation, equilibrium and rocket example problems also verified.

## Compatibility / Numerical behavior
- [ X] No expected changes to numerical results
- [ ] Expected changes (explain and provide validation)
