### PR TITLE
Rocket throat properties now printed even if there's no exit cone

### DIFF
--- a/source/rocket.f90
+++ b/source/rocket.f90
@@ -414,6 +414,8 @@ contains
             soln%i_save = 0
         end if
 
+        call mark_completed(soln, idx)
+
     end subroutine
 
     subroutine RocketSolver_solve_throat_frozen(self, soln, idx, n_frz, pc, h_inf, awt)


### PR DESCRIPTION
## Summary
Fixes issue #90 to ensure throat properties are printed on the legacy interface, even if no nozzle expansion points are requested. This aligns with CEA2 behavior.

## Changes
Call mark_completed in Rocket.f90 when RocketSolver_solve_throat completes, duplicating the behavior of RocketSolver_solve_throat_frozen.

## Testing
100% pass for legacy interface tests, ctest, pytest. Manually confirmed proper behavior for various combinations of IAC/FAC, eq /frz options (see attached files).
[example8_chamberThroatOnly.inp.txt](https://github.com/user-attachments/files/28858497/example8_chamberThroatOnly.inp.txt)
[example8_chamberThroatOnly.inp.txt](https://github.com/user-attachments/files/28858497/example8_chamberThroatOnly.inp.txt)
[example8_chamberThroatOnly.out.txt](https://github.com/user-attachments/files/28858499/example8_chamberThroatOnly.out.txt)
[example8_chamberThroatOnly.out.txt](https://github.com/user-attachments/files/28858499/example8_chamberThroatOnly.out.txt)
[example8_frzchamberThroatOnly.inp.txt](https://github.com/user-attachments/files/28858500/example8_frzchamberThroatOnly.inp.txt)
[example8_frzchamberThroatOnly.inp.txt](https://github.com/user-attachments/files/28858500/example8_frzchamberThroatOnly.inp.txt)
[example8_frzchamberThroatOnly.out.txt](https://github.com/user-attachments/files/28858501/example8_frzchamberThroatOnly.out.txt)
[example8_frzchamberThroatOnly.out.txt](https://github.com/user-attachments/files/28858501/example8_frzchamberThroatOnly.out.txt)
[example9_chamberThroatOnly.inp.txt](https://github.com/user-attachments/files/28858502/example9_chamberThroatOnly.inp.txt)
[example9_chamberThroatOnly.inp.txt](https://github.com/user-attachments/files/28858502/example9_chamberThroatOnly.inp.txt)
[example9_chamberThroatOnly.out.txt](https://github.com/user-attachments/files/28858503/example9_chamberThroatOnly.out.txt)
[example9_chamberThroatOnly.out.txt](https://github.com/user-attachments/files/28858503/example9_chamberThroatOnly.out.txt)
[example9_frzchamberThroatOnly.inp.txt](https://github.com/user-attachments/files/28858504/example9_frzchamberThroatOnly.inp.txt)
[example9_frzchamberThroatOnly.inp.txt](https://github.com/user-attachments/files/28858504/example9_frzchamberThroatOnly.inp.txt)
[example9_frzchamberThroatOnly.out.txt](https://github.com/user-attachments/files/28858505/example9_frzchamberThroatOnly.out.txt)
[example9_frzchamberThroatOnly.out.txt](https://github.com/user-attachments/files/28858505/example9_frzchamberThroatOnly.out.txt)


## Compatibility / Numerical behavior
- [ X] No expected changes to numerical results
- [ ] Expected changes (explain and provide validation)
