### PR TITLE
Add reactant valid-temperature range queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable user-visible changes to this project are documented here.
 ### Fixed
 
 ### Added
+- Added Fortran, C, and Python APIs for querying a database reactant's inclusive
+  valid temperature range in Kelvin before constructing a mixture.
 
 ## [3.3.1] - 2026-07-29
 

--- a/source/bind/c/CMakeLists.txt
+++ b/source/bind/c/CMakeLists.txt
@@ -45,6 +45,14 @@ endif()
 
 if (CEA_BUILD_TESTING)
 
+    add_executable(cea_bindc_reactant_temperature_range tests/reactant_temperature_range.c)
+    target_link_libraries(cea_bindc_reactant_temperature_range PRIVATE cea::bindc)
+    add_test(
+        NAME cea_bindc_reactant_temperature_range
+        COMMAND cea_bindc_reactant_temperature_range
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    )
+
     add_executable(cea_bindc_rp1311_ex1 samples/rp1311_example1.c)
     target_link_libraries(cea_bindc_rp1311_ex1 PRIVATE cea::bindc)
     add_test(

--- a/source/bind/c/bindc.F90
+++ b/source/bind/c/bindc.F90
@@ -417,6 +417,33 @@ contains
         end if
     end function
 
+    function cea_reactant_get_valid_temperature_range(cname, T_min, T_max) result(ierr) &
+        bind(c, name="cea_reactant_get_valid_temperature_range_fortran")
+        integer(c_int) :: ierr
+        character(c_char), intent(in) :: cname(*)
+        real(c_double), intent(out) :: T_min, T_max
+        character(:), allocatable :: name
+        integer :: i
+
+        T_min = 0.0d0
+        T_max = 0.0d0
+        if (.not. thermo_initialized) then
+            ierr = CEA_INVALID_SIZE
+            return
+        end if
+
+        call c_copy(cname, name)
+        do i = 1, global_thermodb%num_reactants
+            if (names_match(name, global_thermodb%reactant_name_list(i))) then
+                call global_thermodb%reactant_thermo(i)%get_valid_temperature_range(T_min, T_max)
+                ierr = CEA_SUCCESS
+                return
+            end if
+        end do
+
+        ierr = CEA_INVALID_INDEX
+    end function
+
 
     !-----------------------------------------------------------------
     ! Mixture

--- a/source/bind/c/cea.h
+++ b/source/bind/c/cea.h
@@ -135,6 +135,12 @@ extern "C"
   cea_err cea_init_trans(const cea_string transfile);
   cea_err cea_is_initialized(cea_int *initialized);
 
+  // Inclusive valid temperature bounds for a database reactant, in K
+  cea_err cea_reactant_get_valid_temperature_range(
+      const cea_string name,
+      cea_real *temperature_min,
+      cea_real *temperature_max);
+
   //----------------------------------------------------------------------
   // Mixture API
   //----------------------------------------------------------------------

--- a/source/bind/c/cea_fortran_api.h
+++ b/source/bind/c/cea_fortran_api.h
@@ -17,6 +17,10 @@ jmp_buf *cea_bindc_abort_jmp_buf(void);
 cea_err cea_init_fortran(void);
 cea_err cea_init_thermo_fortran(const cea_string thermofile);
 cea_err cea_init_trans_fortran(const cea_string transfile);
+cea_err cea_reactant_get_valid_temperature_range_fortran(
+    const cea_string name,
+    cea_real *temperature_min,
+    cea_real *temperature_max);
 
 cea_err cea_mixture_create_fortran(
     cea_mixture *mix,

--- a/source/bind/c/cea_recovery.c
+++ b/source/bind/c/cea_recovery.c
@@ -44,6 +44,19 @@ cea_err cea_init_trans(const cea_string transfile)
   CEA_GUARD_END(cea_init_trans_fortran(transfile));
 }
 
+cea_err cea_reactant_get_valid_temperature_range(
+    const cea_string name,
+    cea_real *temperature_min,
+    cea_real *temperature_max)
+{
+  if (name == NULL || temperature_min == NULL || temperature_max == NULL)
+  {
+    return CEA_INVALID_SIZE;
+  }
+  CEA_GUARD_BEGIN();
+  CEA_GUARD_END(cea_reactant_get_valid_temperature_range_fortran(name, temperature_min, temperature_max));
+}
+
 cea_err cea_mixture_create(cea_mixture *mix, const cea_int nspecies, const cea_string species[])
 {
   if (mix != NULL)

--- a/source/bind/c/tests/reactant_temperature_range.c
+++ b/source/bind/c/tests/reactant_temperature_range.c
@@ -1,0 +1,30 @@
+#include "cea.h"
+
+#include <math.h>
+
+int main(void)
+{
+    cea_real temperature_min;
+    cea_real temperature_max;
+
+    if (cea_reactant_get_valid_temperature_range(
+            "(CH2)x(cr)", &temperature_min, &temperature_max) != CEA_INVALID_SIZE) {
+        return 1;
+    }
+    if (cea_init() != CEA_SUCCESS) {
+        return 2;
+    }
+    if (cea_reactant_get_valid_temperature_range(
+            "(CH2)x(cr)", &temperature_min, &temperature_max) != CEA_SUCCESS) {
+        return 3;
+    }
+    if (fabs(temperature_min - 288.15) > 1e-12 || fabs(temperature_max - 308.15) > 1e-12) {
+        return 4;
+    }
+    if (cea_reactant_get_valid_temperature_range(
+            "not-a-reactant", &temperature_min, &temperature_max) != CEA_INVALID_INDEX) {
+        return 5;
+    }
+
+    return 0;
+}

--- a/source/bind/python/CEA.pyx
+++ b/source/bind/python/CEA.pyx
@@ -666,6 +666,40 @@ cdef class Reactant:
         self._enthalpy_core_units = enthalpy_core_units
         self._enthalpy_is_weight_units = bool(enthalpy_is_weight_units)
 
+    def get_valid_temperature_range(self):
+        """
+        Return the inclusive valid temperature bounds for this database reactant.
+
+        Returns
+        -------
+        tuple of float
+            Minimum and maximum valid temperatures in K.
+
+        Raises
+        ------
+        ValueError
+            If ``name`` is not present in the reactant database.
+        RuntimeError
+            If the thermo database is not initialized or the binding call fails.
+
+        Notes
+        -----
+        This is a database-name query. Custom formula, enthalpy, and temperature
+        overrides do not alter the returned bounds.
+        """
+        cdef cea_err ierr
+        cdef cea_real temperature_min
+        cdef cea_real temperature_max
+        cdef _CString encoded_name = _CString(self.name, "Reactant name")
+
+        ierr = cea_reactant_get_valid_temperature_range(
+            encoded_name.ptr, &temperature_min, &temperature_max
+        )
+        if ierr == CEA_INVALID_INDEX:
+            raise ValueError(f"Reactant not found in thermo database: {self.name}")
+        _check_ierr(ierr, "Reactant.get_valid_temperature_range")
+        return float(temperature_min), float(temperature_max)
+
 
 cdef tuple _normalize_enthalpy_units(object enthalpy_units):
     cdef str units_text

--- a/source/bind/python/cea/lib/libcea.pyi
+++ b/source/bind/python/cea/lib/libcea.pyi
@@ -194,6 +194,8 @@ class Reactant:
     enthalpy_units: str | None
     temperature: float | None
 
+    def get_valid_temperature_range(self) -> tuple[float, float]: ...
+
     @overload
     def __init__(
         self,

--- a/source/bind/python/cea_def.pxd
+++ b/source/bind/python/cea_def.pxd
@@ -271,6 +271,8 @@ cdef extern from "cea.h":
     cpdef cea_err cea_init_thermo(const cea_string thermofile)
     cpdef cea_err cea_init_trans(const cea_string transfile)
     cpdef cea_err cea_is_initialized(cea_int *initialized)
+    cpdef cea_err cea_reactant_get_valid_temperature_range(const cea_string name, cea_real *temperature_min,
+                                                            cea_real *temperature_max)
 
     # Mixture
     cpdef cea_err cea_mixture_create(cea_mixture *mix, const cea_int nspecies, const cea_string species[])

--- a/source/bind/python/tests/test_reactant_temperature_range.py
+++ b/source/bind/python/tests/test_reactant_temperature_range.py
@@ -1,0 +1,23 @@
+import pytest
+
+
+def test_reactant_reference_temperature_range_before_mixture(cea_module):
+    reactant = cea_module.Reactant("(CH2)x(cr)")
+
+    temperature_range = reactant.get_valid_temperature_range()
+
+    assert temperature_range == pytest.approx((288.15, 308.15))
+    assert all(isinstance(value, float) for value in temperature_range)
+
+
+def test_reactant_fitted_temperature_range(cea_module):
+    reactant = cea_module.Reactant("NH4CLO4(I)")
+
+    assert reactant.get_valid_temperature_range() == pytest.approx((100.0, 513.15))
+
+
+def test_reactant_temperature_range_rejects_unknown_name(cea_module):
+    reactant = cea_module.Reactant("not-a-reactant")
+
+    with pytest.raises(ValueError, match="not found in thermo database"):
+        reactant.get_valid_temperature_range()

--- a/source/thermo.f90
+++ b/source/thermo.f90
@@ -49,6 +49,7 @@ module cea_thermo
 
     contains
         procedure :: is_condensed => st_is_condensed
+        procedure :: get_valid_temperature_range => st_get_valid_temperature_range
         procedure :: calc_cv => st_calc_cv
         procedure :: calc_cp => st_calc_cp
         procedure :: calc_energy => st_calc_energy
@@ -112,6 +113,20 @@ contains
         logical :: tf
         tf = (self%i_phase > 0)
     end function
+
+    pure subroutine st_get_valid_temperature_range(self, T_min, T_max)
+        !! Return the inclusive temperature bounds for this species in K
+        class(SpeciesThermo), intent(in) :: self
+        real(dp), intent(out) :: T_min, T_max
+
+        if (allocated(self%T_fit)) then
+            T_min = minval(self%T_fit(:, 1))
+            T_max = maxval(self%T_fit(:, 2))
+        else
+            T_min = self%T_ref - 10.0d0
+            T_max = self%T_ref + 10.0d0
+        end if
+    end subroutine
 
     elemental function st_calc_cv(self, T) result(cv)
         class(SpeciesThermo), intent(in) :: self

--- a/source/thermo_test.pf
+++ b/source/thermo_test.pf
@@ -134,6 +134,8 @@ contains
     subroutine test_reactant_thermo()
 
         type(ThermoDB) :: db
+        real(dp) :: T_min, T_max
+        integer :: i
         db = read_thermo("data/thermo.lib")
 
         @assertEqual("(CH2)x(cr)" ,db%reactant_thermo(1)%name)
@@ -146,6 +148,18 @@ contains
         @assertEqual(14.026579999999999d0 ,db%reactant_thermo(1)%molecular_weight)
         @assertEqual(298.14999999999998d0 ,db%reactant_thermo(1)%T_ref)
         @assertEqual(-25600.000000000000d0 ,db%reactant_thermo(1)%enthalpy_ref)
+
+        call db%reactant_thermo(1)%get_valid_temperature_range(T_min, T_max)
+        @assertEqual(288.14999999999998d0, T_min)
+        @assertEqual(308.14999999999998d0, T_max)
+
+        do i = 1, db%num_reactants
+            if (allocated(db%reactant_thermo(i)%T_fit)) exit
+        end do
+        @assertTrue(i <= db%num_reactants)
+        call db%reactant_thermo(i)%get_valid_temperature_range(T_min, T_max)
+        @assertEqual(minval(db%reactant_thermo(i)%T_fit(:, 1)), T_min)
+        @assertEqual(maxval(db%reactant_thermo(i)%T_fit(:, 2)), T_max)
 
         ! @assertEqual("RP-1" ,db%reactant_thermo(62)%name)
         ! @assertEqual("C "  ,db%reactant_thermo(62)%formula%elements(1))


### PR DESCRIPTION
## Summary

Add Fortran, C, and Python APIs for querying a database reactant’s inclusive valid temperature range in Kelvin before constructing a mixture.

## Changes

- Add `SpeciesThermo%get_valid_temperature_range`.
- Return outer fit bounds for fitted reactants and `T_ref ± 10 K` for reference-only reactants.
- Add the public C API `cea_reactant_get_valid_temperature_range`.
- Add Python `Reactant.get_valid_temperature_range()`.
- Handle unknown reactants and uninitialized thermo data through existing error codes.
- Add Fortran, C, and Python regression coverage.

## Testing

- `ctest -R `cea_core_test|cea_bindc_reactant_temperature_range' -V`
- `pytest source/bind/python/tests — 65 passed`
- `Verified touched Fortran files contain no lines over 132 characters.`

## Compatibility / Numerical behavior

[x] No expected changes to numerical results
[] Expected changes (explain and provide validation)