### PR TITLE
fix: correct stale version numbers and update version-increment check…

### DIFF
--- a/.codex/skills/version-increment/SKILL.md
+++ b/.codex/skills/version-increment/SKILL.md
@@ -17,13 +17,15 @@ Use this skill when the user provides a new version number and wants the repo pr
 - `CMakeLists.txt` (`project(... VERSION x.y.z)`).
 - `source/bind/python/cea/__init__.py` (`__version__ = "x.y.z"`).
 - `docs/source/conf.py` (`release = '...'`).
+- `project.md` (`version: x.y.z`) — FORD doc-generator metadata; currently unreferenced elsewhere in the repo/CI, kept accurate in case FORD is reintroduced.
+- `Doxyfile` (`PROJECT_NUMBER = x.y.z`) — Doxygen config invoked by docs.yml; feeds the Doxygen->Breathe->Sphinx pipeline but the value itself doesn't appear to render on the published site.
 
 Update these locations and verify no additional hard-coded version literals remain outside generated docs.
 
 ## Workflow
 
 1. Validate `new_version` format and ensure it is greater than the current version.
-2. Update the three known hard-coded version locations.
+2. Update the five known hard-coded version locations.
 3. Search for additional stale literals:
    - Prefer `rg -n "<old_version>|release\s*=|__version__\s*=|VERSION\s+[0-9]+\.[0-9]+\.[0-9]+"`
    - Exclude generated docs: `docs/_build/`, `docs/doxygen/`.

--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = "CEA"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 3.0
+PROJECT_NUMBER         = 3.3.2
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewers a

--- a/project.md
+++ b/project.md
@@ -1,6 +1,6 @@
 ---
 project: CEA
-version: 3.0
+version: 3.3.2
 src_dir: ./source
 output_dir: ./docs
 project_github: https://github.com/nasa/cea


### PR DESCRIPTION
## Summary
Corrects stale version numbers (`3.0`) in two doc-generator config files that were left behind at previous releases, and closes the gap in the version-increment checklist that let this happen.

Note: this change has no visible effect on the currently published docs site — see the "Investigated impact" notes below.

## Changes
- `project.md`: `version: 3.0` → `3.3.2` (FORD doc-generator metadata)
- `Doxyfile`: `PROJECT_NUMBER = 3.0` → `3.3.2` (Doxygen config)
- `.codex/skills/version-increment/SKILL.md`: added both files to the known hard-coded version locations list

Investigated impact before fixing:
- `project.md`/FORD: not referenced anywhere in the repo outside itself — appears unused by the current docs pipeline (`docs.yml` only invokes Doxygen + Sphinx, never `ford`). I corrected the value here in case FORD is still intended for future use, but if it's actually dead weight, happy to open a follow-up PR removing `project.md` entirely instead — just let me know which you'd prefer.
- `Doxyfile`: actively used — invoked by `docs.yml` in CI, and referenced in `developer_guide.rst`/`faq.rst`/`installation.rst` for local dev workflows — but `PROJECT_NUMBER` specifically feeds the intermediate Doxygen→Breathe→Sphinx pipeline and doesn't appear to render on the published site. The live docs' correct version comes from `docs/source/conf.py`, which was already accurate.

## Testing
- `ctest` not applicable — no solver/numerics changes.
- Ran `doxygen Doxyfile` directly to confirm the corrected value doesn't break XML generation — completed successfully (one pre-existing, unrelated `DOT_MULTI_TARGETS` deprecation warning, unaffected by this change).
- `project.md` and `SKILL.md` have no associated build/test step (confirmed via repo-wide text search for each filename, excluding build artifacts).

## Compatibility / Numerical behavior
- [x] No expected changes to numerical results

---
I used Claude to help investigate this repo's docs pipeline and draft this description; the findings above were verified directly against the source (grep searches, reading `docs.yml`, running `doxygen Doxyfile` locally, and inspecting the generated XML/HTML output) rather than taken on faith.