### PR TITLE
Fix imprecise psi-to-bar conversion constant in Python bindings

### DIFF
--- a/source/bind/python/cea/units/__init__.py
+++ b/source/bind/python/cea/units/__init__.py
@@ -71,7 +71,10 @@ def kelvin_to_rankine(value):
 # Pressure --------------------------------------------------------------------
 
 _ATM_TO_BAR = 1.01325
-_PSI_TO_BAR = _ATM_TO_BAR/14.696006
+# 1 atm = 14.695948775513 psi, derived from the exact SI base-unit definitions
+# of the lbf, inch, and atm. Matches the Fortran core's psi_to_bar
+# (source/units.f90) to ~9 significant figures.
+_PSI_TO_BAR = _ATM_TO_BAR/14.695948775513
 _MMHG_TO_BAR = _ATM_TO_BAR/760.0
 
 


### PR DESCRIPTION
Corrects an imprecise psi-to-bar conversion constant in the Python bindings that disagreed with the equivalent Fortran core constant and the SI-derived value.

## Changes

- `source/bind/python/cea/units/__init__.py`: `_PSI_TO_BAR` divisor `14.696006` -> `14.695948775513`; updated the accompanying comment.

**atm to psi derivation:**
- psi, inch, pound-force, and atm are all exactly defined by SI (not measured quantities), so the true conversion factor is an exact rational number rather than an approximation.
- Computed directly from the defining exact constants:
  - 1 lb = 0.45359237 kg
  - standard gravity = 9.80665 m/s^2
  - 1 in = 0.0254 m
  - 1 atm = 101325 Pa

Using the above defined factors:

    1 atm = 14.695948775513448725503472157154729689217877000033... psi   (exact)
    1 psi = 0.068947572931683613367226734453468906937813875627751... bar (exact)

The Fortran core (`source/units.f90:43`) already uses a much closer value (`bar = psi*0.0689475729d0`) than Python's prior constant did -- Python was the outlier, not Fortran.

Each candidate compared against the true exact value above, rounded to the nearest representable float64:

| Candidate                                   | Value                   | Relative error vs. exact value | Effective accuracy         |
|-----------------------------------------------|---------------------------|------------------------------------|-------------------------------|
| Exact SI-derived value (reference)           | 0.06894757293168361...  | --                                   | exact                          |
| This PR (1.01325/14.695948775513)            | 0.06894757293168573     | 3.06e-14                             | ~14 significant figures       |
| Fortran core (0.0689475729d0)                | 0.0689475729            | 4.60e-10                             | ~9-10 significant figures     |
| Previous constant                            | 0.06894730445809562     | 3.89e-6                              | ~5-6 significant figures      |

This PR uses the SI-derived value rather than hardcoding to match Fortran's literal bit-for-bit; the two are within ~4.6e-10 relative of each other (functionally indistinguishable for any CEA calculation), so it came down to traceability to a primary standard over matching another file's rounding.

No strong opinion here -- happy to switch `_PSI_TO_BAR` to the literal `0.0689475729` instead if maintainers would rather match the Fortran core exactly.

## Testing

- `pytest source/bind/python/tests` -- all 68 tests pass, including the RP-1311 examples 11-13 (`test_rp1311_samples.py`), which exercise `psi_to_bar` under `rel=1e-5`/`1e-4` tolerances comfortably wider than this change's ~3.9e-6 relative shift.
- `source/bind/python/cea/units/__init__.py` has no dedicated test file of its own -- its conversions are currently only exercised indirectly, as inputs to the RP-1311 example tests above (e.g. `cea.units.psi_to_bar(1000.0)` used to set chamber pressure in examples 11-13). A standalone `test_units.py` asserting the conversion functions directly would be a good follow-up, but is out of scope for this single-constant fix.
- No rebuild needed -- plain .py file, not .pyx/.pxd.

## Compatibility / Numerical behavior
- [ ] No expected changes to numerical results
- [x] Expected changes (explain and provide validation)

Only `psi_to_bar`/`bar_to_psi` are affected (via `_PSI_TO_BAR`); no other conversions in this file change, and no Fortran core, `thermo.inp`, or `trans.inp` changes were made. Relative change is ~3.9e-6 (~0.0003 bar at 1000 psi).

While the relative change is very small, it was performed in accordance with CONTRIBUTING.md: 'Numerical correctness > performance > style'

I used Claude to help investigate this discrepancy and draft this description; the findings above were verified directly -- recomputed from exact SI base-unit definitions, cross-checked against source/units.f90, and validated against the existing pytest suite -- rather than taken on faith.
