### PR TITLE
Document issue/PR templates in CLAUDE.md contribution workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,12 @@ Test locations:
 - scikit-build-core
 - Ninja (build time)
 
+## Contribution Workflow
+
+- Before opening or drafting an issue, use the appropriate template in `.github/ISSUE_TEMPLATE/` (`bug_report.md` or `feature_request.md`).
+- Before opening or drafting a pull request, follow `.github/pull_request_template.md` — fill in every section (Summary, Changes, Testing, Compatibility/Numerical behavior).
+- See [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow, including when to open an issue first vs. going straight to a PR for small, well-scoped changes.
+
 ## References
 
 When in doubt, refer to:


### PR DESCRIPTION
## Summary

Adds an explicit "Contribution Workflow" section to `CLAUDE.md` that points AI agents directly at `.github/ISSUE_TEMPLATE/*` and `.github/pull_request_template.md`, rather than relying on the passive `CONTRIBUTING.md` link buried in the `References` section at the bottom.

## Changes

- `CLAUDE.md`: added a `## Contribution Workflow` section (placed before `## References`) with three bullets — use the issue templates in `.github/ISSUE_TEMPLATE/` before opening or drafting an issue, follow `.github/pull_request_template.md` before opening or drafting a pull request, and defer to `CONTRIBUTING.md` for the full workflow.

**Why here, and why explicit:**
- `CLAUDE.md` is auto-loaded into every AI-agent session on this repo; `CONTRIBUTING.md` is not — an agent only reads it if it goes looking for it.
- This traces to a specific incident during the psi_to_bar precision fix (previous PR). The agent had read `CONTRIBUTING.md` early in that session, which itself documents `.github/ISSUE_TEMPLATE/bug_report.md` and `feature_request.md`. The miss wasn't triggered by any particular wording from the user — it followed two consecutive clarifying-question exchanges (confirming an issue-first plan, then choosing to receive pasteable issue text), and the agent's very next response opened with a freeform-structured draft (`## What`, `## Why this is a bug`, `## Impact`, `## Proposed fix`) instead of the template's actual fields, with no user text in between that could have steered it off course. The correction only came once the user explicitly asked for template conformance.
- We tried to reproduce this before writing this PR: asking a fresh agent session (running the pre-this-PR `CLAUDE.md`) to investigate and draft an issue for an analogous bug — a similar Python/Fortran unit-conversion mismatch — via a single, explicit written request. It used the real template correctly both times, unprompted. So the failure didn't reproduce under those conditions; a closer replay would need to stage the original menu-selection sequence rather than a typed request, which didn't seem worth chasing precisely, since the original incident is already documented from that session's own history and this fix costs essentially nothing either way.
- "Opening or drafting" (rather than just "opening") is deliberate for the same reason: an agent typically drafts issue/PR content for a human to review and submit, rather than submitting it directly, so the rule needs to bind at drafting time, not just at submission.

## Testing

- Not run — this is a documentation-only change to `CLAUDE.md`; no code, build, or test files are touched.
- Verified via `git diff` that the change is scoped to the single new section in `CLAUDE.md`, with no other files modified.

## Compatibility / Numerical behavior
- [x] No expected changes to numerical results

I used Claude to help draft this description, including surfacing the concrete issue-template example above from the psi_to_bar PR session and running the reproduction attempts described; I reviewed the `CLAUDE.md` change directly against the file's existing structure, and confirmed both the original incident and the reproduction results against actual session history before including them here.