### PR TITLE
Update AtomicData table to current IUPAC/CIAAW standard atomic weights

### DIFF
--- a/source/atomic_data.f90
+++ b/source/atomic_data.f90
@@ -17,113 +17,128 @@ module cea_atomic_data
 
     end type
 
-    type(Atomic), parameter :: AtomicData(106) = [ &
-        Atomic("H ", 1.00794d0   ,  1.), &
-        Atomic("IH", 1.00794d0   ,  1.), &
-        Atomic("D ", 2.014102d0  ,  1.), &
-        Atomic("HE", 4.002602d0  ,  0.), &
-        Atomic("LI", 6.941d0     ,  1.), &
-        Atomic("BE", 9.012182d0  ,  2.), &
-        Atomic("B ", 10.811d0    ,  3.), &
-        Atomic("C ", 12.0107d0   ,  4.), &
-        Atomic("IC", 12.0107d0   ,  4.), &
-        Atomic("N ", 14.0067d0   ,  0.), &
-        Atomic("O ", 15.9994d0   , -2.), &
-        Atomic("IO", 15.9994d0   , -2.), &
-        Atomic("F ", 18.9984032d0, -1.), &
-        Atomic("NE", 20.1797d0   ,  0.), &
-        Atomic("NA", 22.989770d0 ,  1.), &
+    type(Atomic), parameter :: AtomicData(103) = [ &
+        !! Standard atomic weights are IUPAC/CIAAW's current values (accessed
+        !! 2026-08-24): https://www.ciaaw.org/abridged-atomic-weights.htm
+        !! Deliberately kept at CIAAW's own 5-significant-digit abridged
+        !! precision throughout (their recommendation since 2013) rather than
+        !! the more precise unabridged table -- see the PR for why.
+        !!
+        !! Interval-notation elements (e.g. Li, H, Cl) reflect real natural
+        !! variation, not measurement uncertainty -- don't "fix" one by averaging
+        !! it. The value here is IUPAC's own conventional recommendation, not
+        !! the interval's midpoint.
+        !!
+        !! Elements with no standard atomic weight (plus D) use CIAAW's
+        !! recommended isotope's mass instead
+        !! (https://www.ciaaw.org/radioactive-elements.htm), at AME2020's full
+        !! published precision (https://www-nds.iaea.org/amdc/ame2020/mass_1.mas20.txt)
+        !! -- unlike standard atomic weights, isotope masses have no abridged
+        !! form to defer to, so full precision is used rather than an invented
+        !! shorter one; see the PR for why.
+        Atomic("H ", 1.008d0     ,  1.), &
+        Atomic("IH", 1.008d0     ,  1.), &   ! Inert hydrogen
+        Atomic("D ", 2.014101777844d0 ,  1.), &   ! Deuterium atomic mass (not a standard atomic weight); ciaaw.org/hydrogen.htm
+        Atomic("HE", 4.0026d0    ,  0.), &
+        Atomic("LI", 6.94d0      ,  1.), &
+        Atomic("BE", 9.0122d0    ,  2.), &
+        Atomic("B ", 10.81d0     ,  3.), &
+        Atomic("C ", 12.011d0    ,  4.), &
+        Atomic("IC", 12.011d0    ,  4.), &   ! Inert carbon
+        Atomic("N ", 14.007d0    ,  0.), &
+        Atomic("O ", 15.999d0    , -2.), &
+        Atomic("IO", 15.999d0    , -2.), &   ! Inert oxygen
+        Atomic("F ", 18.998d0    , -1.), &
+        Atomic("NE", 20.180d0    ,  0.), &
+        Atomic("NA", 22.990d0    ,  1.), &
         Atomic("MG", 24.305d0    ,  2.), &
-        Atomic("AL", 26.981538d0 ,  3.), &
-        Atomic("SI", 28.0855d0   ,  4.), &
-        Atomic("P ", 30.973761d0 ,  5.), &
-        Atomic("S ", 32.065d0    ,  4.), &
-        Atomic("CL", 35.453d0    , -1.), &
-        Atomic("AR", 39.948d0    ,  0.), &
-        Atomic("K ", 39.0983d0   ,  1.), &
+        Atomic("AL", 26.982d0    ,  3.), &
+        Atomic("SI", 28.085d0    ,  4.), &
+        Atomic("P ", 30.974d0    ,  5.), &
+        Atomic("S ", 32.06d0     ,  4.), &
+        Atomic("CL", 35.45d0     , -1.), &
+        Atomic("AR", 39.95d0     ,  0.), &
+        Atomic("K ", 39.098d0    ,  1.), &
         Atomic("CA", 40.078d0    ,  2.), &
-        Atomic("SC", 44.95591d0  ,  3.), &
+        Atomic("SC", 44.956d0    ,  3.), &
         Atomic("TI", 47.867d0    ,  4.), &
-        Atomic("V ", 50.9415d0   ,  5.), &
-        Atomic("CR", 51.9961d0   ,  3.), &
-        Atomic("MN", 54.938049d0 ,  2.), &
+        Atomic("V ", 50.942d0    ,  5.), &
+        Atomic("CR", 51.996d0    ,  3.), &
+        Atomic("MN", 54.938d0    ,  2.), &
         Atomic("FE", 55.845d0    ,  3.), &
-        Atomic("CO", 58.933200d0 ,  2.), &
-        Atomic("NI", 58.6934d0   ,  2.), &
+        Atomic("CO", 58.933d0    ,  2.), &
+        Atomic("NI", 58.693d0    ,  2.), &
         Atomic("CU", 63.546d0    ,  2.), &
-        Atomic("ZN", 65.39d0     ,  2.), &
+        Atomic("ZN", 65.38d0     ,  2.), &
         Atomic("GA", 69.723d0    ,  3.), &
-        Atomic("GE", 72.64d0     ,  4.), &
-        Atomic("AS", 74.92160d0  ,  3.), &
-        Atomic("SE", 78.96d0     ,  4.), &
+        Atomic("GE", 72.630d0    ,  4.), &
+        Atomic("AS", 74.922d0    ,  3.), &
+        Atomic("SE", 78.971d0    ,  4.), &
         Atomic("BR", 79.904d0    , -1.), &
-        Atomic("KR", 83.80d0     ,  0.), &
-        Atomic("RB", 85.4678d0   ,  1.), &
+        Atomic("KR", 83.798d0    ,  0.), &
+        Atomic("RB", 85.468d0    ,  1.), &
         Atomic("SR", 87.62d0     ,  2.), &
-        Atomic("Y ", 88.90585d0  ,  3.), &
-        Atomic("ZR", 91.224d0    ,  4.), &
-        Atomic("NB", 92.90638d0  ,  5.), &
-        Atomic("MO", 95.94d0     ,  6.), &
-        Atomic("TC", 97.9072d0   ,  7.), &
+        Atomic("Y ", 88.906d0    ,  3.), &
+        Atomic("ZR", 91.222d0    ,  4.), &
+        Atomic("NB", 92.906d0    ,  5.), &
+        Atomic("MO", 95.95d0     ,  6.), &
+        Atomic("TC", 97.907211206d0 ,  7.), &   ! No standard weight; mass of Tc-98 (CIAAW: Tc-97/Tc-98 equally stable)
         Atomic("RU", 101.07d0    ,  3.), &
-        Atomic("RH", 102.9055d0  ,  3.), &
+        Atomic("RH", 102.91d0    ,  3.), &
         Atomic("PD", 106.42d0    ,  2.), &
-        Atomic("AG", 107.8682d0  ,  1.), &
-        Atomic("CD", 112.411d0   ,  2.), &
-        Atomic("IN", 114.818d0   ,  3.), &
-        Atomic("SN", 118.710d0   ,  4.), &
-        Atomic("SB", 121.760d0   ,  3.), &
+        Atomic("AG", 107.87d0    ,  1.), &
+        Atomic("CD", 112.41d0    ,  2.), &
+        Atomic("IN", 114.82d0    ,  3.), &
+        Atomic("SN", 118.71d0    ,  4.), &
+        Atomic("SB", 121.76d0    ,  3.), &
         Atomic("TE", 127.6d0     ,  4.), &
-        Atomic("I ", 126.90447d0 , -1.), &
-        Atomic("XE", 131.293d0   ,  0.), &
-        Atomic("CS", 132.90545d0 ,  1.), &
-        Atomic("BA", 137.327d0   ,  2.), &
-        Atomic("LA", 138.9055d0  ,  3.), &
-        Atomic("CE", 140.116d0   ,  3.), &
-        Atomic("PR", 140.90765d0 ,  3.), &
-        Atomic("ND", 144.9127d0  ,  3.), &
-        Atomic("PM", 145.d0      ,  3.), &
+        Atomic("I ", 126.90d0    , -1.), &
+        Atomic("XE", 131.29d0    ,  0.), &
+        Atomic("CS", 132.91d0    ,  1.), &
+        Atomic("BA", 137.33d0    ,  2.), &
+        Atomic("LA", 138.91d0    ,  3.), &
+        Atomic("CE", 140.12d0    ,  3.), &
+        Atomic("PR", 140.91d0    ,  3.), &
+        Atomic("ND", 144.24d0    ,  3.), &
+        Atomic("PM", 144.912755748d0 ,  3.), &   ! No standard weight; mass of Pm-145
         Atomic("SM", 150.36d0    ,  3.), &
-        Atomic("EU", 151.964d0   ,  3.), &
+        Atomic("EU", 151.96d0    ,  3.), &
         Atomic("GD", 157.25d0    ,  3.), &
-        Atomic("TB", 158.92534d0 ,  3.), &
+        Atomic("TB", 158.93d0    ,  3.), &
         Atomic("DY", 162.50d0    ,  3.), &
-        Atomic("HO", 164.93032d0 ,  3.), &
-        Atomic("ER", 167.259d0   ,  3.), &
-        Atomic("TM", 168.93421d0 ,  3.), &
-        Atomic("YB", 173.04d0    ,  3.), &
-        Atomic("LU", 174.967d0   ,  3.), &
+        Atomic("HO", 164.93d0    ,  3.), &
+        Atomic("ER", 167.26d0    ,  3.), &
+        Atomic("TM", 168.93d0    ,  3.), &
+        Atomic("YB", 173.05d0    ,  3.), &
+        Atomic("LU", 174.97d0    ,  3.), &
         Atomic("HF", 178.49d0    ,  4.), &
-        Atomic("TA", 180.9479d0  ,  5.), &
+        Atomic("TA", 180.95d0    ,  5.), &
         Atomic("W ", 183.84d0    ,  6.), &
-        Atomic("RE", 186.207d0   ,  7.), &
+        Atomic("RE", 186.21d0    ,  7.), &
         Atomic("OS", 190.23d0    ,  4.), &
-        Atomic("IR", 192.217d0   ,  4.), &
-        Atomic("PT", 195.078d0   ,  4.), &
-        Atomic("AU", 196.96655d0 ,  3.), &
+        Atomic("IR", 192.22d0    ,  4.), &
+        Atomic("PT", 195.08d0    ,  4.), &
+        Atomic("AU", 196.97d0    ,  3.), &
         Atomic("HG", 200.59d0    ,  2.), &
-        Atomic("TL", 204.3833d0  ,  1.), &
+        Atomic("TL", 204.38d0    ,  1.), &
         Atomic("PB", 207.2d0     ,  2.), &
-        Atomic("BI", 208.98038d0 ,  3.), &
-        Atomic("PO", 208.9824d0  ,  2.), &
-        Atomic("AT", 209.9871d0  , -1.), &
-        Atomic("RN", 222.0176d0  ,  0.), &
-        Atomic("FR", 223.0197d0  ,  1.), &
-        Atomic("RA", 226.0254d0  ,  2.), &
-        Atomic("AC", 227.0278d0  ,  3.), &
-        Atomic("TH", 232.0381d0  ,  4.), &
-        Atomic("PA", 231.03588d0 ,  5.), &
-        Atomic("U ", 238.02891d0 ,  6.), &
-        Atomic("NP", 237.0482d0  ,  5.), &
-        Atomic("PU", 244.0642d0  ,  4.), &
-        Atomic("AM", 243.0614d0  ,  3.), &
-        Atomic("CM", 247.0703d0  ,  3.), &
-        Atomic("BK", 247.0703d0  ,  3.), &
-        Atomic("CF", 251.0587d0  ,  3.), &
-        Atomic("ES", 252.083d0   ,  3.), &
-        Atomic("IH", 1.00794d0   ,  1.), &
-        Atomic("IC", 12.0107d0   ,  4.), &
-        Atomic("IO", 15.9994d0   , -2.) &
+        Atomic("BI", 208.98d0    ,  3.), &
+        Atomic("PO", 208.982430361d0 ,  2.), &   ! No standard weight; mass of Po-209
+        Atomic("AT", 209.987147423d0 , -1.), &   ! No standard weight; mass of At-210
+        Atomic("RN", 222.017576017d0 ,  0.), &   ! No standard weight; mass of Rn-222
+        Atomic("FR", 223.019734241d0 ,  1.), &   ! No standard weight; mass of Fr-223
+        Atomic("RA", 226.025408186d0 ,  2.), &   ! No standard weight; mass of Ra-226
+        Atomic("AC", 227.027750594d0 ,  3.), &   ! No standard weight; mass of Ac-227
+        Atomic("TH", 232.04d0    ,  4.), &
+        Atomic("PA", 231.04d0    ,  5.), &
+        Atomic("U ", 238.03d0    ,  6.), &
+        Atomic("NP", 237.048171640d0 ,  5.), &   ! No standard weight; mass of Np-237
+        Atomic("PU", 244.064204401d0 ,  4.), &   ! No standard weight; mass of Pu-244
+        Atomic("AM", 243.061379889d0 ,  3.), &   ! No standard weight; mass of Am-243
+        Atomic("CM", 247.070352678d0 ,  3.), &   ! No standard weight; mass of Cm-247
+        Atomic("BK", 247.070305889d0 ,  3.), &   ! No standard weight; mass of Bk-247
+        Atomic("CF", 251.079587171d0 ,  3.), &   ! No standard weight; mass of Cf-251
+        Atomic("ES", 252.082979173d0 ,  3.) &    ! No standard weight; mass of Es-252
     ]
 
 contains


### PR DESCRIPTION
Title: Update AtomicData table to current IUPAC/CIAAW standard atomic weights

## Summary
`source/atomic_data.f90`'s `AtomicData` table had no cited source and a mix of stale values, outright errors, and inconsistent precision. This conforms all 103 entries to two traceable policies: CIAAW's "abridged" Standard Atomic Weights (their recommended 5-significant-digit form since 2013) for ordinary elements, and AME2020's full published precision for the 16 isotope masses (D plus 15 elements with no standard atomic weight at all -- no "abridged" convention exists for those, so full precision is used instead of inventing a shorter one). 81 of 103 entries change.

## Changes and Findings

### `thermo.inp`'s own species weights are untouched, and now diverge slightly
`thermo.inp` bakes a molecular weight into every compiled species at compile time, completely independent of this table -- e.g. `Ag`'s entry carries `107.8682000` regardless of what `atomic_data.f90` says. Before this PR, that baked value exactly matched `atomic_data.f90`'s old entry for all 54 elements that have an elemental reference species in `thermo.inp` (Ag, Al, Ar, B, ... Zr) -- the old table wasn't leftover cruft, it was synced to `thermo.inp`'s own IUPAC vintage. Abridging breaks that exact match: most differ by <10 ppm (coincidental last-digit rounding), but ~12 (Li, B, C, S, Cl, Ar, Zn, Ge, Kr, Zr, Mo, Ag) diverge by 20-160 ppm, reflecting real IUPAC revisions since `thermo.inp` was compiled, not just abridging. No functional effect: `get_atom_weight` is called from exactly one place in the whole codebase (`mixture.f90:1180`, inside `molecular_weight_from_formula`) -- `thermo.inp`'s baked value is what's actually used for every compiled species, named or elemental, always. Still worth flagging since a reviewer diffing `thermo.inp` by eye (as happened here) will see numbers that no longer match and might assume a bug.

Some options based on this information (found right before submitting the PR):

- **Accept the divergence** (what this PR currently does) -- consistent with the whole premise: one current, externally-cited authority, instead of an undocumented sync to whatever `thermo.inp` happened to use in 1997.
- **Update `thermo.inp` to match**, in a future PR -- bigger than it looks: that MW field is baked into every *compound* containing the element, not just the 54 elemental references, and this repo's own rules say don't touch `thermo.inp`/`trans.inp` without explicit instruction. Worth its own issue, not this PR.
- **Revert `atomic_data.f90` to match `thermo.inp`, document the gap** -- if that means reverting all 54, it throws away the "one consistent, externally-verifiable policy" this PR argues for, to preserve an agreement that was never itself documented as intentional. Independent of the Nd/Cf/Cm/Pm fixes either way -- none of those four have a `thermo.inp` elemental reference to sync with, so they stand regardless of which option is picked. Middle ground: keep the abridging policy, just note the ~54-element gap in the header -- which this section already does.

### Two outright errors, unexplained by any historical IUPAC value
- Nd: 144.9127 -> 144.24 (off by ~0.5 amu; matches Pm-145's isotope mass, the row right below it -- looks like a transcription slip)
- Cf: 251.0587 -> 251.0796 (off by ~0.02 amu; matches no published Cf value)

### 16 isotope masses (D + 15 no-standard-weight elements): verified against AME2020, two corrected, all carried at full precision
Verified all 16 directly against the raw AME2020 file (https://www-nds.iaea.org/amdc/ame2020/mass_1.mas20.txt). Two were wrong:
- Cm: 247.0703 -> 247.070352678 (should round to ...0704; tiny but real drift)
- Pm: 145.0 -> 144.912755748 (was a bare mass number, not a mass)

Tc: CIAAW's radioactive-elements page treats Tc-97 and Tc-98 as equally stable, so the value closest to the pre-existing table (Tc-98's mass) was kept, just expanded to full precision.

The other 12 (Po, At, Rn, Fr, Ra, Ac, Np, Pu, Am, Bk, Es, D) were already numerically correct, just truncated to ~7 figures instead of AME2020's ~10-13. All 16 are now at AME2020's full precision instead (e.g. Cf is 251.079587171, not 251.0796): unlike standard atomic weights, no source -- not CIAAW, not AME2020's own "rounded" table (which only trims for print formatting) -- publishes a shorter recommended form for isotope masses, so the prior ~7-figure convention was just unanchored truncation like everywhere else in this PR. And unlike standard atomic weights, isotope masses are single measured constants, not natural averages with real sample variation -- so there's no "over-precise for what's truly known" concern here either.

### 64 elements conformed to CIAAW's abridged 5-significant-digit precision
The rest of the changed elements were already numerically fine, just inconsistent: some (18) carried a stale pre-revision digit; the remaining 46 had simply never been touched and still carried 6-9 figures of leftover full-precision digits from whenever the table was compiled. All 64 now match https://www.ciaaw.org/abridged-atomic-weights.htm exactly -- see that page or `git diff` to verify any individual value; not reproduced as a table here.

CIAAW's own 2013 report says the full table's precision "exceeds the needs and interests of many users" and that 5 digits (vs. 4) is the right abridged form. That's their recommendation for general use, not proof CEA needs it -- so it's worth checking directly: the full-vs-abridged gap here is ~14 ppm (e.g. Nd 144.242 vs 144.24). CEA's own thermo data (`data/thermo.inp`'s NASA polynomial curve fits) carries ~0.1-1% accuracy, and real combustion predictions are trusted to a few percent at best -- both 1,000x+ larger than this gap, for reasons unrelated to atomic weights. The extra digit is real, not noise, but it can never surface in any CEA output, so one consistent, externally-verifiable precision policy is worth more than keeping it.

### What "IH"/"IC"/"IO" are
Not formally documented anywhere -- checked RP-1311 Parts 1 & 2 (no mention), `source/*.f90` (nothing outside this PR's own new comments), and `data/thermo.inp` (species use them but nothing defines them). The reading here is inference, not a cited fact: every `Inert*`-named species (InertH, InertCH4, InertJP-4, etc.) uses only IH/IC/IO in its formula, in stoichiometric counts matching its real-element formula, and one comment comes close to spelling it out -- `InertAir`'s reads "(Just copied from above, note that all O inerted)", using "inerted" as a verb for the O -> IO swap. The *function* is independently confirmed by working code, though: `equilibrium_test.pf`'s `test_inert_reactant` swaps in a separate `thermo-inert.lib` and shows InertJP-4/InertCH4/InertC10H8 passing through the solver unreacted. So CEA clearly uses these pseudo-elements to give a reactant real thermodynamic data while keeping its atoms out of the real H/C/O element-balance pool -- "Inert" is the best label for that behavior, just not a documented one. Their weight should still equal the real element's regardless of what "I" stands for -- the live IH/IC/IO entries were updated to match, and three *dead* duplicate rows at the end of the array (unreachable -- `get_atom` exits on the first name match) were removed; `AtomicData`'s declared size dropped from 106 to 103 to match.

### Source citations added to the header comment
The table cited nothing before. The header now cites, and briefly explains:
1. **Abridged Standard Atomic Weights** (ciaaw.org/abridged-atomic-weights.htm) -- primary source for ordinary elements, including the 8 CIAAW publishes as an interval elsewhere (H, Li, B, C, S, Cl, Ar, Tl). That interval isn't measurement uncertainty to average away -- it's real source-to-source variation in natural isotopic composition (lithium is the textbook case). The value used is IUPAC's own "conventional" recommendation, not the interval's midpoint (Tl's, 204.38, sits below its whole interval).
2. **Radioactive elements** (ciaaw.org/radioactive-elements.htm) -- which isotope to use for the 15 no-standard-weight elements; gives a mass number only, not a precise mass.
3. **AME2020** (mass_1.mas20.txt) -- source for all 16 isotope masses, used at full precision

**Valence is untouched.** Every `valence` value is byte-for-byte identical (only `atomic_weight` was edited). Worth noting because the two fields feed very differently-scoped code in `mixture.f90`: `get_atom_weight` is narrow -- only used for a user-supplied reactant defined by formula with no explicit molecular weight (`molecular_weight_from_formula`, mixture.f90:1165-1184). `get_atom_valence` is broad -- used for every element in a mixture via `mixture_get_valence`, implementing RP-1311 Eq. (9.18) for O/F-ratio / equivalence-ratio conversion, exercised by essentially any fuel+oxidant problem. Untouched valence means that broader path is provably unaffected.

## Testing
- [x] Valence unchanged -- confirmed by diff inspection (exhaustive for a literal constant table), not a test run.
- [x] `cmake --build build-dev` -- clean across every pass.
- [x] `ctest --test-dir build-dev` -- 14/14 passed each pass. These are run-to-completion smoke tests, not reference-value checks.
- [x] `python test/main_interface/test_main.py` (1% tolerance vs. reference `.out` files) -- 14/14 passed. Checked which samples actually exercise `get_atom_weight` rather than assuming "contains the element" is enough: 13 of 14 use only named reactants, which get their molecular weight from the compiled `thermo.inp` database, not `atomic_data.f90` -- unaffected by this PR regardless of pass/fail. Example 5 is the one real exercise: its "CHOS-Binder" reactant is given by formula (`C 1 H 1.86955 O .031256 S .008415`, no explicit molecular weight -- its own comment says why: "not available in thermo.lib"), so it genuinely calls `molecular_weight_from_formula` using this PR's updated C/H/O/S weights, and it passed within 1% tolerance.
- [x] `pytest source/bind/python/tests` -- 68/68 passed against a genuine fresh rebuild. Directly confirmed live: a pure-Li formula reactant converts 1 mole to 6.94 g via `Mixture.moles_to_weights`.
- [x] Checked `data/thermo.inp` for all 16 isotope-mass symbols: 13 don't appear at all. D and Rn do appear, but only as pre-compiled species with their own literal molecular weight baked in at database-compile time -- `get_atom_weight` only fires for a formula-defined reactant with no explicit MW, so these compiled entries are untouched.
- [ ] No existing test specifically exercises the rarer corrected elements -- a small `atomic_data_test.pf` would close that gap; not bundled here.
- [ ] No existing test exists to ensure congruence between `thermo.inp` and `atomic_data.f90`

## Compatibility / Numerical behavior
- [x] Expected changes (explain and provide validation)

This changes computed molecular weight for any species using one of the 64 precision-conformed elements or the 2 outright-error fixes. Nd, Cf, Tc, Pm, Cm, and 10 other isotope-mass entries are unused anywhere in the current database/test suite (inert in practice); D and Rn are technically live paths but touch nothing currently compiled either. Every individual change is small -- outright errors under 0.02%, precision-conformance under 15 ppm, isotope-mass expansions smaller still -- well below CEA's own existing uncertainty (see above). Still a real numerical-behavior change per CONTRIBUTING.md, not a docs/style fix, given how much of the table it touches.

---
Drafted with Claude's assistance
- I cross-checked all 103 elements against CIAAW's Abridged and Radioactive-elements pages
- I verified all 16 isotope masses directly against the raw AME2020 file
- Checked AME2020's own "rounded" table and CIAAW's hydrogen page to confirm no abridged convention applies to isotope masses before expanding them to full precision
- grepped `data/thermo.inp` for all 16 isotope symbols and traced how `get_atom_weight` is actually invoked before concluding D/Rn's presence in the file doesn't affect current output
- Checked RP-1311, the Fortran source, and `thermo.inp` for a documented definition of "Inert"/IH/IC/IO; found none