### PR TITLE
Fix calc_dcv_dT to return dCv/dT instead of Cv

### DIFF
--- a/source/fits.f90
+++ b/source/fits.f90
@@ -112,11 +112,11 @@ contains
         g = g/T + (self%a2 - T*self%a3)*logT
     end function
 
-    elemental function calc_dcv_dT(self,T) result(cv)
+    elemental function calc_dcv_dT(self,T) result(dcv_dT)
         class(ThermoFit), intent(in) :: self
         real(dp), intent(in) :: T
-        real(dp) :: cv
-        cv = self%calc_cp(T) - 1.0d0
+        real(dp) :: dcv_dT
+        dcv_dT = self%calc_dcp_dT(T)
     end function
 
     elemental function calc_dcp_dT(self,T) result(dcp_dT)

--- a/source/fits_test.pf
+++ b/source/fits_test.pf
@@ -55,6 +55,7 @@ contains
         cp = fit%calc_cp(T)
         @assertRelativelyEqual(cp, fit%calc_denthalpy_dT(T), tol)
         @assertRelativelyEqual(cp/T, fit%calc_dentropy_dT(T), tol)
+        @assertRelativelyEqual(fit%calc_dcp_dT(T), fit%calc_dcv_dT(T), tol)
     end subroutine
 
 end module


### PR DESCRIPTION
## Summary

`calc_dcv_dT` in `source/fits.f90` computed Cv, not dCv/dT — a copy-paste artifact from `calc_cv`. The bug is currently dormant (no code path calls `calc_dcv_dT` today), but the function would silently return the wrong value the moment anything did call it.

## Changes

- `source/fits.f90`: `calc_dcv_dT` now delegates to `calc_dcp_dT(T)` instead of recomputing `calc_cp(T) - 1.0d0`. Since Cv/R = Cp/R − 1 (Cp − Cv = R for an ideal gas), differentiating with respect to T drops the constant −1, so d(Cv/R)/dT = d(Cp/R)/dT exactly — matching the existing pattern in `calc_denergy_dT`, which delegates to `calc_denthalpy_dT(T)` the same way rather than re-deriving it. Also renamed the result variable from `cv` to `dcv_dT` to match the naming convention already used by the other `_dT` derivative functions (`dcp_dT`, `de_dT`, `dh_dT`, `ds_dT`).
- `source/fits_test.pf`: added a regression assertion to the existing `test_thermo_derivatives` test, checking `calc_dcv_dT(T) == calc_dcp_dT(T)` to a relative tolerance of 1e-12.

## Testing

- `cmake --build build-dev` succeeds with no new warnings from the touched files.
- All 14 tests registered in this build (`cea_main_test*`, the 9 RP-1311 example cases, `cea_bindc_reactant_temperature_range`, `cea_bindc_shock_last_valid`) pass before and after the change — no regressions.
- Could not run the new `fits_test.pf` assertion locally: it lives in the pFUnit-based `cea_core_test` suite, and pFUnit isn't installed in this dev environment. Attempted to build pFUnit v4.19.0 from source but hit a missing `m4` dependency pulled in transitively by its `gFTL` submodule, not available as a win-64 conda-forge package. Per the developer guide, pFUnit is a maintainer-only dependency, so leaving this test to run in CI / a maintainer's pFUnit-enabled environment rather than chasing the toolchain gap further.
- Verified the fix by hand instead: evaluated both the buggy and corrected formulas at T=600K using the NO curve-fit coefficients already in `fits_test.pf` (TP-2002-211556). The buggy code returns Cp/R − 1 ≈ 2.757264 (i.e. it was returning Cv, not dCv/dT); the corrected code returns d(Cp/R)/dT ≈ 0.000950 — over three orders of magnitude apart, confirming the fix actually changes the output and that the new assertion would catch a regression back to the old behavior.

## Compatibility / Numerical behavior

- [ ] No expected changes to numerical results
- [x] Expected changes (explain and provide validation)

`calc_dcv_dT`'s return value changes for any caller (previously returned Cv/R, now returns the correct dCv/dT). However, grepping `source/*.f90` found no call sites for `calc_dcv_dT`/`dcv_dT` outside its own definition and type-bound declaration — the function is currently unreachable from any live solver path, so no existing calculation's output changes. This is fixing a latent bug ahead of the function ever being called, not a behavior change to any current results.

---

Drafted with Claude's assistance

- The dCv/dT = dCp/dT derivation was checked both symbolically (Cp/R − Cv/R equals 1, a constant independent of T, so it vanishes under differentiation) and numerically, evaluating the old and new formulas by hand against the real NO fit coefficients at T=600K (shown above).
- Confirmed via `grep` that `calc_dcv_dT` has no existing callers anywhere in `source/*.f90`, so this PR carries no live behavioral change today.
- Ran the full locally-buildable test suite (14 tests) before and after the change to confirm no regressions; the new pFUnit assertion itself could not be executed locally (see Testing section) and should be checked in CI or a pFUnit-enabled environment before merge.
