### PR TITLE
Use is_active instead of nj-tolerance for frozen condensed species check

### DIFF
--- a/source/rocket.f90
+++ b/source/rocket.f90
@@ -345,9 +345,8 @@ contains
                 ! composition point, not the species' overall span.
                 in_range = .true.
                 do j = 1, self%eq_solver%num_condensed
-                    ! TODO(smooth_truncation): smooth gating means species are rarely exactly zero.
-                    ! Frozen-mode checks intentionally use a practical-zero tolerance.
-                    if (abs(soln%eq_soln(n_frz)%nj(ng+j)) <= approx_zero_tol) cycle
+                    ! Only validate species actually present in the frozen composition.
+                    if (.not. soln%eq_soln(n_frz)%is_active(j)) cycle
                     call frozen_fit_bounds(self%eq_solver%products%species(ng+j), soln%eq_soln(n_frz)%T, T_low, T_high)
                     if (soln%eq_soln(idx)%T < (T_low-phase_gap) .or. soln%eq_soln(idx)%T > (T_high+phase_gap)) then
                         in_range = .false.

--- a/source/rocket_test.pf
+++ b/source/rocket_test.pf
@@ -533,6 +533,12 @@ contains
         @assertRelativelyEqual(38.038d0, soln%pressure(2), tol)
         @assertRelativelyEqual(1.0d0, soln%mach(2), tol)
         @assertRelativelyEqual(1466.5d0, soln%c_star(2), tol)
+
+        ! C(gr) is active (nj ~ 3.4e-3) at the frozen point, and points 1-2
+        ! above complete before point 3 fails -- so the frozen thermo-interval
+        ! check exercises its success path (in_range = .true.) for an active
+        ! condensed species here, not just the failure path above.
+        @assertTrue(soln%eq_soln(1)%is_active(1))
     end subroutine
 
     @test


### PR DESCRIPTION
<!-- Suggested PR title: -->
<!-- Use is_active instead of nj-tolerance check for frozen condensed species -->

## Summary

`rocket.f90`'s frozen-mode thermo-interval check decided whether to skip a condensed species using an `approx_zero_tol` comparison on `nj`, with a comment attributing this to `smooth_truncation`'s smooth gating. That attribution doesn't hold for condensed species: they're governed by the solver's hard `is_active` flag (`equilibrium.f90`), not the continuous logistic gate (`compute_nj_effective`) that only applies to gas species. This swaps the check to `is_active` directly, so it asks the solver's own state rather than relying on the "nj gets zeroed whenever is_active goes false" pairing holding across every future edit.

Related: #104 requests letting a condensed species transition to another phase of the same stoichiometry instead of stopping when it leaves its valid temperature range — a change to what happens after this same check fails, not to how the check decides which species to validate. Not implemented here; noting the connection since both touch this exact loop in `RocketSolver_frozen`.

## Changes

- `source/rocket.f90` (frozen-mode thermo-interval check, previously lines 347-350): replaced `if (abs(soln%eq_soln(n_frz)%nj(ng+j)) <= approx_zero_tol) cycle` with `if (.not. soln%eq_soln(n_frz)%is_active(j)) cycle`, removed the now-inapplicable `TODO(smooth_truncation)` comment, and added a one-line comment on the new check ("Only validate species actually present in the frozen composition."). Mirrors the pattern already used a few lines earlier in the same subroutine (line 316) for the analogous condensed-species loop over `cpsum`/`ssum`.
- `source/rocket_test.pf` (`test_rocket_frozen_partial_output_fail1`): added one assertion, `@assertTrue(soln%eq_soln(1)%is_active(1))`. The existing test's mixture happens to activate `C(gr)` at the frozen point with a non-trivial amount (`nj ≈ 3.4e-3`) and completes points 1-2 before failing at point 3 — so it was already exercising the check's success path (`in_range = .true.`) for an active species, just not asserting on it. Confirmed via temporary debug instrumentation (not part of this diff) rather than assumed.

| Term | Meaning |
|---|---|
| `n_frz` | Station index where composition is frozen (fixed for the whole solve) |
| `idx` | Station currently being evaluated (chamber, throat, or an exit point) |
| `j` | Condensed-species index (1..`num_condensed`) |
| `ng+j` | That species' position in the combined gas+condensed `nj`/`is_active` arrays |
| `nj` | Species molar amount [kmol]; `nj(ng+j)` is condensed species `j`'s amount at the given station |

## Testing

- **Equivalence proof, one direction confirmed solid — every `deactivate_condensed` call site in the file audited, not just a sample:** grepped every occurrence (9 total) and checked each one. Every path agrees: `inactive ⟹ nj == 0.0` exactly, so the old tolerance check (`abs(nj) <= 1e-12`) and the new `is_active` check agree on every species either check has ever actually deactivated.
    - 6 direct call sites (lines 1789, 1880, 2014, 2041, 2058, 2620) zero `nj(ng+idx)` on the very next line.
    - 2 sites that go through `replace_active_condensed` (lines 1711, 1750) have their caller zero it two lines after the call.
    - The 9th, inside `EqPartials_compute_partials` (line 4739, reached when partials/transport are requested right after a solve converges — real mutation of the stored `EqSolution`, not a copy), zeroes `nj` two lines *before* deactivating rather than after, but the guarantee still holds by the time `is_active` flips.
    - A 10th occurrence, inside `activate_condensed` at line 4260, deactivates and immediately reactivates the same index as internal rank-shuffling bookkeeping — never externally observable as deactivated, so it doesn't bear on this.
- **One direction not proven, worth a maintainer's eyes:** the converse — `active ⟹ nj` comfortably above `1e-12` — isn't a hard invariant anywhere in the solver. Checked deliberately, not assumed: went through all 9 `deactivate_condensed` call sites above and confirmed every single one fires for a specific triggering condition (temperature out of range, singular/element-row-singular matrix, a high-temperature fallback, phase switching, or the partial-derivative liquid/solid merge) — none of them is a generic "amount got too small, deactivate" floor. So unlike gas species, which get smoothly floored via `compute_nj_effective` whenever `smooth_truncation` is on, condensed species have no minimum-magnitude gate at all; one can in principle stay flagged active with an arbitrarily small (even sub-`1e-12`) amount indefinitely, as long as none of those other conditions happen to fire first. The old code silently skipped the interval check for such a species; the new code would validate it, and could now trip the "outside thermo range" warning where before it wouldn't have. No test case here (or found by inspection) hits that combination, and if it ever does, the new behavior is arguably the more correct one (checking an active species' interval rather than skipping it) — but it's a real, if narrow, behavior change, not a proven no-op. Flagging as a candidate follow-up question (should condensed species get a minimum-activity floor?) rather than something to resolve in this PR, since a real fix means touching *when* species get deactivated — solver algorithm territory, not just how this check reads state.
- Built via `ninja` in `build-dev`, no new warnings from either touched file.
- Ran the full suite with pFUnit now available locally (`ctest --test-dir build-dev`): 15/15 pass, including `cea_core_test`'s 118 individual pFUnit assertions — `rocket_test.pf`'s `test_rocket_frozen_partial_output_fail1`/`_fail2` (including the new assertion above) all pass.

## Compatibility / Numerical behavior

- [ ] No expected changes to numerical results
- [x] Expected changes (explain and provide validation)

Equivalent for every condensed species state reachable by any deactivation path checked above (see Testing). Not proven equivalent for the theoretical active-but-near-zero edge case described above — flagging per the numerical-behavior-change convention rather than asserting a stronger guarantee than what was actually verified.

---

Drafted with Claude's assistance

- All `deactivate_condensed`/`replace_active_condensed` call sites were located by grep and read directly, not taken on an earlier session's notes — those notes had gone stale (wrong line numbers) after intervening PRs shifted `equilibrium.f90`, which is what prompted re-verifying them here.
- The active-but-near-zero caveat came from deliberately checking both directions of the equivalence claim rather than stopping once the first (inactive ⟹ zero) direction checked out.
- The new regression assertion's value (`C(gr)` active, `nj ≈ 3.4e-3`) was read from an actual instrumented run of the existing test, not estimated or assumed.
- Ran the full test suite, including the pFUnit-based `cea_core_test` (previously not runnable in this environment; pFUnit was built from source for this session — out of scope for this PR, but will be filed in the future).
