### PR TITLE
Fix Python RocketSolver weight validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable user-visible changes to this project are documented here.
 ### Changed
 
 ### Fixed
+- Python `RocketSolver.solve` now rejects weight arrays with the wrong shape or
+  reactant count before calling native code, preventing out-of-bounds reads,
+  NaNs, and nondeterministic results when `reactants` is accidentally omitted.
+  The error points to `reactants=reac`; valid products-as-reactants calls remain
+  supported, with no numerical changes for valid inputs.
 
 ### Added
 

--- a/docs/source/interfaces/python_api.rst
+++ b/docs/source/interfaces/python_api.rst
@@ -35,6 +35,13 @@ EqSolution
 RocketSolver
 ------------
 
+Pass ``reactants=reac`` to ``cea.RocketSolver(prod, reactants=reac)`` when the
+reactant and product mixtures differ. If ``reactants`` is omitted, the solver
+uses ``prod`` as both mixtures. In that case, ``solve`` requires one weight for
+every species in ``prod.species_names`` order, including zeros for absent species.
+The weights must be a one-dimensional array of length ``solver.num_reactants``;
+an invalid shape or length raises ``ValueError`` before the native solver runs.
+
 .. autoclass:: cea.RocketSolver
    :members:
 

--- a/source/bind/python/CEA.pyx
+++ b/source/bind/python/CEA.pyx
@@ -2295,7 +2295,9 @@ cdef class RocketSolver:
         Mixture object containing product species
     **kwargs
         reactants : Mixture, optional
-            Mixture object containing reactant species
+            Mixture object containing reactant species. If omitted, products is
+            also used as the reactant mixture; solve weights must then include
+            one entry per product species in products.species_names order.
         transport : bool, default False
             Enable transport property calculations
         ions : bool, default False
@@ -2454,7 +2456,10 @@ cdef class RocketSolver:
         soln : RocketSolution
             Solution object to store results
         weights : np.ndarray
-            Reactant mass fractions
+            One-dimensional reactant mass fractions, with exactly num_reactants
+            entries in the reactant mixture's species_names order. If reactants
+            was omitted when constructing the solver, use products.species_names
+            order and include an entry for every product species.
         pc : float
             Chamber pressure in bar
         pi_p : float, list, or np.ndarray, optional
@@ -2481,10 +2486,22 @@ cdef class RocketSolver:
         Raises
         ------
         ValueError
-            If conflicting parameters are provided
+            If weights is not one-dimensional, its length does not match
+            num_reactants, or conflicting parameters are provided
         """
         cdef cea_err ierr
+        if weights is None or weights.ndim != 1:
+            raise ValueError("RocketSolver.solve: weights must be a one-dimensional array")
+
         cdef int nweights = <int>len(weights)
+        cdef int nreactants = self.num_reactants
+        if nweights != nreactants:
+            raise ValueError(
+                f"RocketSolver.solve: weights must contain one entry per reactant species "
+                f"(expected {nreactants}, got {nweights}). "
+                "Pass reactants=reac when constructing RocketSolver if the weights "
+                "refer to a separate reactant mixture."
+            )
 
         cdef cea_array wts = <cea_array>malloc(nweights * sizeof(double))
         if wts == NULL:

--- a/source/bind/python/cea/lib/libcea.pyi
+++ b/source/bind/python/cea/lib/libcea.pyi
@@ -508,6 +508,8 @@ class EqDerivatives:
 
 
 class RocketSolver:
+    """Rocket solver; omitted reactants defaults to the products mixture."""
+
     @overload
     def __init__(
         self,
@@ -558,7 +560,13 @@ class RocketSolver:
         mdot: float | None = None,
         ac_at: float | None = None,
         tc_est: float | None = None,
-    ) -> None: ...
+    ) -> None:
+        """Require 1D weights of length num_reactants in reactant species order.
+
+        If reactants was omitted, weights must follow products.species_names.
+        Invalid weight shapes or lengths raise ValueError.
+        """
+        ...
 
 
 class RocketSolution:

--- a/source/bind/python/tests/test_validation.py
+++ b/source/bind/python/tests/test_validation.py
@@ -36,6 +36,63 @@ def test_rocket_solver_rejects_conflicting_hc_tc(cea_module):
         solver.solve(soln, weights, pc=10.0, pi_p=2.0, hc=100.0, tc=3000.0)
 
 
+@pytest.mark.parametrize("iac", [True, False])
+def test_rocket_solver_rejects_weights_for_omitted_reactants(cea_module, iac):
+    _, products, weights = _basic_reactants(cea_module)
+    solver = cea_module.RocketSolver(products)
+    soln = cea_module.RocketSolution(solver)
+    assert solver.num_reactants > len(weights)
+
+    with pytest.raises(ValueError, match="reactants=reac") as exc:
+        solver.solve(soln, weights, pc=10.0, pi_p=2.0, tc=3000.0, iac=iac, ac_at=2.0)
+    assert f"expected {solver.num_reactants}, got {len(weights)}" in str(exc.value)
+
+
+@pytest.mark.parametrize("iac", [True, False])
+@pytest.mark.parametrize("weight_count", [0, 1, 3])
+def test_rocket_solver_rejects_wrong_weight_count(cea_module, iac, weight_count):
+    reactants, products, weights = _basic_reactants(cea_module)
+    solver = cea_module.RocketSolver(products, reactants=reactants)
+    soln = cea_module.RocketSolution(solver)
+    invalid_weights = np.zeros(weight_count)
+    count = min(weight_count, len(weights))
+    invalid_weights[:count] = weights[:count]
+
+    with pytest.raises(ValueError, match=f"expected 2, got {weight_count}"):
+        solver.solve(soln, invalid_weights, pc=10.0, pi_p=2.0, tc=3000.0, iac=iac, ac_at=2.0)
+
+
+@pytest.mark.parametrize("weights", [None, np.array(1.0), np.ones((1, 2)), np.ones((2, 1))])
+def test_rocket_solver_rejects_non_vector_weights(cea_module, weights):
+    reactants, products, _ = _basic_reactants(cea_module)
+    solver = cea_module.RocketSolver(products, reactants=reactants)
+    soln = cea_module.RocketSolution(solver)
+
+    with pytest.raises(ValueError, match="weights must be a one-dimensional array"):
+        solver.solve(soln, weights, pc=10.0, pi_p=2.0, tc=3000.0)
+
+
+@pytest.mark.parametrize("iac", [True, False])
+def test_rocket_solver_defaults_to_product_reactants(cea_module, iac):
+    reactants, products, weights = _basic_reactants(cea_module)
+    product_weights = np.zeros(products.num_species)
+    for species, weight in zip(reactants.species_names, weights):
+        product_weights[products.species_names.index(species)] = weight
+
+    default_solver = cea_module.RocketSolver(products)
+    explicit_solver = cea_module.RocketSolver(products, reactants=products)
+    default_soln = cea_module.RocketSolution(default_solver)
+    explicit_soln = cea_module.RocketSolution(explicit_solver)
+    for solver, soln in ((default_solver, default_soln), (explicit_solver, explicit_soln)):
+        solver.solve(soln, product_weights, pc=10.0, pi_p=2.0, tc=3000.0, iac=iac, ac_at=2.0)
+        assert soln.converged
+
+    for prop in ("T", "P", "Isp", "Mach", "nj"):
+        actual = getattr(default_soln, prop)
+        assert np.all(np.isfinite(actual))
+        np.testing.assert_array_equal(actual, getattr(explicit_soln, prop))
+
+
 def test_shock_solver_requires_one_input(cea_module):
     reactants_mix, products_mix, weights = _basic_reactants(cea_module)
     solver = cea_module.ShockSolver(products_mix, reactants=reactants_mix)


### PR DESCRIPTION

## Summary

Prevent out-of-bounds reads, NaNs, and nondeterministic results when omitted reactants cause a weight-count mismatch.

## Changes

- Reject invalid weight shapes and lengths before calling native code.
- Include guidance to pass `reactants=reac` in length-mismatch errors.
- Preserve valid products-as-reactants usage.
- Update documentation, type-stub documentation, changelog, and regression tests.

## Testing

- `make py-rebuild` succeeded.
- `pytest source/bind/python/tests`: 113 passed.
- All 30 result arrays across six valid IAC/FAC cases remained bitwise identical.

## Compatibility / Numerical behavior

- [x] No expected changes to numerical results
- [ ] Expected changes (explain and provide validation)

Invalid weight arrays now raise `ValueError`; valid inputs retain existing behavior.