### PR TITLE
Trim element symbol in atomic_data abort message

### DIFF
--- a/source/atomic_data.f90
+++ b/source/atomic_data.f90
@@ -152,7 +152,7 @@ contains
 
         ! Error if symbol not found
         if (idx(1) < 1) then
-            call abort("Symbol "//symbol//" not found in the element list.")
+            call abort("Symbol "//trim(symbol)//" not found in the element list.")
         end if
 
         ! Select the Atomic object


### PR DESCRIPTION
## Summary

Fixes a stray space in the "Symbol not found" abort message in `get_atom` (`source/atomic_data.f90`) when the element symbol is a single letter.

## Changes

`symbol` is a fixed 2-character field (`element_name_len = 2`), so for single-letter symbols like `H` it's stored as `"H "` with a trailing space. The abort message embedded `symbol` directly instead of trimming it, producing `Symbol H  not found in the element list.` (double space) instead of `Symbol H not found in the element list.`. Every other `abort()` call in the codebase that embeds a variable name trims it first (see `mixture.f90`, `input.f90`, `equilibrium.f90`) — this was the one outlier. Added `trim()` around `symbol` in the one `abort()` call at `source/atomic_data.f90:155`.

## Testing
- Built and ran the full test suite (`core-c` preset, GNU/gfortran on Windows): all 14 tests pass.
- Manually reproduced the abort path with a crafted input (`reac name Test Q 1 wt%=100`, an unrecognized single-letter element in an exploded formula, forcing `molecular_weight_from_formula` -> `get_atom_weight` -> `get_atom`). Confirmed the message changed from a double space to a single space: `CRITICAL: Symbol Q not found in the element list.`

## Compatibility / Numerical behavior
- [x] No expected changes to numerical results

This only changes the text of an error message on an abort path; it does not touch any numerical computation.

---

Drafted with Claude's assistance

- Confirmed the bug and the fix by reading `source/atomic_data.f90` directly (the `element_name_len = 2` field and the single `abort()` call missing `trim()`), and by grepping every other `abort()` call site to verify the `trim()` pattern is otherwise universal.
- Built the project (`core-c` preset) and ran `ctest` — all 14 existing tests passed before and after the change.
- Reproduced the bug end-to-end with a real `cea.exe` invocation before and after the fix to confirm the message actually changes as described, rather than trusting the diff alone.
