### PR TITLE
Reconcile CONTRIBUTING.md and developer_guide.rst on GFE/pFUnit setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,19 +137,28 @@ At minimum, contributors should verify that:
 CEA uses pFUnit (part of the Goddard Fortran Ecosystem) for unit testing. Tests are enabled via the `CEA_BUILD_TESTING` CMake option.
 
 **Prerequisites:**
-1. Clone GFE into the `extern/` directory:
+1. Clone GFE (which vendors pFUnit) into `extern/gfe`, then build and install
+   it so CMake's `find_package(PFUNIT)` can find it:
    ```bash
-   cd extern
-   git clone https://github.com/Goddard-Fortran-Ecosystem/GFE.git
-   cd GFE
-   git submodule update --init
+   git clone https://github.com/Goddard-Fortran-Ecosystem/GFE extern/gfe
+   cd extern/gfe && git submodule update --init && cd ../..
+   cmake -S extern/gfe -B build-dev/extern/gfe -G "Unix Makefiles" \
+       -DCMAKE_CXX_COMPILER=g++ -DCMAKE_Fortran_COMPILER=gfortran \
+       -DCMAKE_INSTALL_PREFIX=build-dev/install -DCMAKE_BUILD_TYPE=Release \
+       -DSKIP_MPI=YES -DSKIP_OPENMP=YES -DSKIP_FHAMCREST=YES -DSKIP_ESMF=YES -DSKIP_ROBUST=YES
+   cmake --build build-dev/extern/gfe --target install
    ```
+   `scripts/develop.sh` automates these steps.
 
-2. Configure CEA with testing enabled (the `dev*` presets enable this by default):
+2. Configure CEA against that install and build (the `dev*` presets enable
+   `CEA_BUILD_TESTING` by default):
    ```bash
-   cmake --preset dev
+   cmake --preset dev -DCMAKE_PREFIX_PATH=build-dev/install
    cmake --build build-dev
    ```
+   If you already have PFUnit installed separately instead of building the
+   vendored copy above, set `PFUNIT_DIR` to its install prefix instead of
+   `CMAKE_PREFIX_PATH`.
 
 **Running all tests:**
 ```bash

--- a/docs/source/developer_guide.rst
+++ b/docs/source/developer_guide.rst
@@ -55,7 +55,9 @@ Prerequisites
 * Optional but strongly recommended: `Doxygen <https://www.doxygen.nl/>`_ to
   regenerate the XML that feeds the Sphinx API docs, and `PFUnit
   <https://github.com/Goddard-Fortran-Ecosystem/pFUnit>`_ support libraries for
-  unit testing (vendored in ``extern/GFE``).
+  unit testing, available via the vendored `GFE
+  <https://github.com/Goddard-Fortran-Ecosystem/GFE>`_ dependency (built into
+  ``extern/gfe``; see :ref:`testing` below).
 
 We provide a ``environment.yml`` file for quickly provisioning a ``conda`` /
 ``mamba`` environment with the complete toolchain::
@@ -128,6 +130,8 @@ Because the binding links against the ``libcea`` artifacts produced by CMake,
 rebuild the project whenever you touch Fortran sources before rerunning Python
 tests.
 
+.. _testing:
+
 Testing
 -------
 
@@ -141,9 +145,12 @@ whenever you modify solver behavior.
 
   (execute from the corresponding build directory).
 
-  PFUnit is a maintainer-only dependency; to run these tests locally, install
-  PFUnit (https://github.com/Goddard-Fortran-Ecosystem/pFUnit) and set ``PFUNIT_DIR``
-  to its install prefix.
+  Building this suite requires PFUnit, which is available via the vendored
+  GFE dependency. See `CONTRIBUTING.md <../../CONTRIBUTING.md>`_'s "Running
+  Tests" section for the full clone/build/install procedure
+  (``scripts/develop.sh`` automates it).
+  If you already have PFUnit installed separately, set ``PFUNIT_DIR`` to its
+  install prefix instead of building the vendored copy.
 
 * **CLI regression test** – ``ctest`` also registers ``cea_main_test`` which
   runs every RP‑1311 example input in ``samples/`` and checks the exit status of


### PR DESCRIPTION
## Summary

CONTRIBUTING.md and docs/source/developer_guide.rst gave two different, non-reconciled procedures for getting pFUnit/GFE available so the pFUnit-based `cea_core_test` suite can build and run. Neither matched what actually works (the `extern/gfe` path used by `scripts/develop.sh`).

https://github.com/djkees/cea/issues/53

## Changes

- CONTRIBUTING.md's "Running Tests" prerequisites: standardized the clone target on `extern/gfe` (lowercase), matching `.gitignore` and `scripts/develop.sh` — the old instructions cloned into `extern/GFE`, which isn't the path `.gitignore` actually ignores. Added the missing build+install step for the vendored GFE/pFUnit copy and the `-DCMAKE_PREFIX_PATH=build-dev/install` flag CEA's own `cmake --preset dev` needs to find it — cloning alone (the old instructions) was never enough for `find_package(PFUNIT)` to succeed. Documented `scripts/develop.sh` as the automated equivalent, and `PFUNIT_DIR` as the alternative for an already-installed PFUnit.
- docs/source/developer_guide.rst: fixed the Prerequisites section's `extern/GFE` capitalization to match, and replaced the Testing section's contradictory "PFUnit is a maintainer-only dependency, install it yourself" text (which conflicted with the Prerequisites section's own claim that it's vendored) with a cross-link to CONTRIBUTING.md's now-accurate procedure, so the two docs describe one consistent story instead of two different ones.

## Testing
- Documentation-only change. Verified against `.gitignore` (only `extern/gfe` and `extern/install` are ignored, not `extern/GFE`) and `scripts/develop.sh` (which clones into `extern/gfe`, builds it with the same `-DSKIP_*` flags now documented, and passes `-DCMAKE_PREFIX_PATH` to the CEA configure step) — the documented procedure is scripts/develop.sh's steps written out manually, not a new invented procedure. Also confirmed `CMakeLists.txt` only calls bare `find_package(PFUNIT)` with no default search path, which is why `CMAKE_PREFIX_PATH`/`PFUNIT_DIR` has to be set explicitly.

## Compatibility / Numerical behavior
- [x] No expected changes to numerical results

## Update

This PR originally added a note that the vendored pFUnit build "currently fails" on Windows and is effectively Linux/macOS-only. That turned out to have a real fix (the `#ifndef _WIN32` guard in pFUnit's `FUnit.F90` is already there, but gfortran doesn't predefine `_WIN32` the way a C/C++ compiler does, so the guard picks the wrong branch) — see #135 in this same batch. That caveat has been dropped from CONTRIBUTING.md/developer_guide.rst here since it's no longer accurate.

**Merge-order dependency:** this PR should merge at the same time as or after #135, not before — merging this first (dropping the caveat) while `main` still lacks #135's fix would leave CONTRIBUTING.md briefly overclaiming Windows support.

---

Drafted with Claude's assistance
- The `extern/GFE` vs `extern/gfe` mismatch and the missing build/install/CMAKE_PREFIX_PATH steps were found by direct comparison of CONTRIBUTING.md's old instructions against `.gitignore` and `scripts/develop.sh`, not assumed from the issue text.
- Confirmed `CMakeLists.txt` has no automatic path to a vendored GFE install (plain `find_package(PFUNIT)`), which is why the old CONTRIBUTING.md steps (clone, then `cmake --preset dev`) could never have worked as written.
