### PR TITLE
Define _WIN32 for gfortran when building vendored pFUnit on Windows

### DIFF
--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -108,16 +108,30 @@ if [ "$BUILD_GFE" = true ]; then
         git clone https://github.com/Goddard-Fortran-Ecosystem/GFE "${GFE}"
         (cd "${GFE}" && git submodule update --init)
     fi
-    cmake -S "${GFE}" -B "${GFE_BUILD}" -G "${GENERATOR}" \
-        -DCMAKE_CXX_COMPILER="${CXX}" \
-        -DCMAKE_Fortran_COMPILER="${FC}" \
-        -DCMAKE_INSTALL_PREFIX="${INSTALL}" \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DSKIP_MPI=YES \
-        -DSKIP_OPENMP=YES \
-        -DSKIP_FHAMCREST=YES \
-        -DSKIP_ESMF=YES \
+    GFE_CMAKE_ARGS=(
+        -DCMAKE_CXX_COMPILER="${CXX}"
+        -DCMAKE_Fortran_COMPILER="${FC}"
+        -DCMAKE_INSTALL_PREFIX="${INSTALL}"
+        -DCMAKE_BUILD_TYPE=Release
+        -DSKIP_MPI=YES
+        -DSKIP_OPENMP=YES
+        -DSKIP_FHAMCREST=YES
+        -DSKIP_ESMF=YES
         -DSKIP_ROBUST=YES
+    )
+    case "$(uname -s)" in
+        MINGW*|MSYS*|CYGWIN*)
+            # gfortran's -cpp preprocessor does not predefine _WIN32 the way a
+            # C/C++ compiler does, but pFUnit's FUnit.F90 guards its
+            # `use pf_RegexFilter` on `#ifndef _WIN32` while pFUnit's own
+            # CMakeLists excludes RegexFilter.F90 from the build via CMake's
+            # own (always-correct) WIN32 variable. Without this define,
+            # FUnit.F90 fails to compile: it tries to use a module that was
+            # never built.
+            GFE_CMAKE_ARGS+=(-DCMAKE_Fortran_FLAGS=-D_WIN32)
+            ;;
+    esac
+    cmake -S "${GFE}" -B "${GFE_BUILD}" -G "${GENERATOR}" "${GFE_CMAKE_ARGS[@]}"
     cmake --build ${GFE_BUILD} --target install -j ${JOBS}
 fi
 


### PR DESCRIPTION
## Summary

`scripts/develop.sh`'s GFE/pFUnit build fails on Windows at the `funit-main` target: `FUnit.F90` guards `use pf_RegexFilter` on `#ifndef _WIN32`, but gfortran's `-cpp` preprocessing does not predefine `_WIN32` the way a C/C++ compiler does, so the guard silently takes the wrong branch and tries to use a module that pFUnit's own CMakeLists correctly excluded from the Windows build via CMake's `WIN32` variable.

https://github.com/djkees/cea/issues/163

## Changes

- `scripts/develop.sh`: on Windows (detected via `uname -s` matching `MINGW*`/`MSYS*`/`CYGWIN*`), pass `-DCMAKE_Fortran_FLAGS=-D_WIN32` when configuring the vendored GFE build, so `FUnit.F90`'s existing `#ifndef _WIN32` guard sees the same platform signal CMake's own `WIN32` check does. No change on Linux/macOS.

This depends on nothing else, but https://github.com/djkees/cea/pull/165 currently has a doc change that assumes this fix is in place (it drops the "Windows: currently fails" caveat from CONTRIBUTING.md) — that PR should merge at the same time as or after this one, not before, or CONTRIBUTING.md would briefly overclaim Windows support.

## Testing

Reproduced the exact failure from #163, then verified the fix end-to-end from a clean configure:
```bash
cmake -S extern/gfe -B build-dev/extern/gfe -G "Unix Makefiles" \
    -DCMAKE_CXX_COMPILER=g++ -DCMAKE_Fortran_COMPILER=gfortran \
    -DCMAKE_INSTALL_PREFIX=build-dev/install -DCMAKE_BUILD_TYPE=Release \
    -DSKIP_MPI=YES -DSKIP_OPENMP=YES -DSKIP_FHAMCREST=YES -DSKIP_ESMF=YES -DSKIP_ROBUST=YES \
    -DCMAKE_Fortran_FLAGS=-D_WIN32
cmake --build build-dev/extern/gfe --target funit-main   # previously failed at FUnit.F90:46 — now builds
cmake --build build-dev/extern/gfe --target install      # completes, produces PFUNITConfig.cmake
```
Went further and built CEA itself against that install (`core-c` preset, `CEA_BUILD_TESTING=ON`) and ran the pFUnit suite on Windows for what's believed to be the first time: `ctest -R cea_core_test -V` — 124/124 tests passed.

## Compatibility / Numerical behavior
- [x] No expected changes to numerical results

---
Drafted with Claude's assistance
- The `_WIN32`-not-predefined-by-gfortran diagnosis was confirmed directly: preprocessing a minimal `#ifndef _WIN32` test program with and without an explicit `-D_WIN32`, using the same gfortran binary from the `cea-dev` conda env, showed the guard picks the wrong branch without the flag.
- The fix was verified end-to-end, not just configured: a full GFE/pFUnit build+install succeeded where it previously failed with the exact error from #163, and CEA's own `cea_core_test` pFUnit suite (124 tests) was built and run against that install on Windows, all passing.

