### PR TITLE
Fix dangling ceam.pyx reference in MATLAB README

### DIFF
--- a/source/bind/matlab/README.md
+++ b/source/bind/matlab/README.md
@@ -20,13 +20,9 @@ Recommended approach:
   ``ShockSolution`` / ``DetonationSolution`` object.
 - The wrapper module is pure Python. The ``CEA_ENABLE_BIND_MATLAB`` CMake
   option is a compatibility knob for MATLAB-via-Python workflows; it does not
-  build a separate supported ``ceam`` extension.
+  build a separate native MATLAB extension.
 - Example scripts live in ``source/bind/matlab/samples/``:
   ``equilibrium_example.m``, ``rocket_example.m``, ``shock_example.m``,
   ``detonation_example.m``.
-
-Legacy note:
-- ``source/bind/matlab/ceam.pyx`` is an old experimental artifact and is not the
-  supported interface path.
 
 If you need a native MATLAB interface, please open an issue or contribute fixes.


### PR DESCRIPTION
## Summary
https://github.com/djkees/cea/issues/22 — the MATLAB binding README referenced `source/bind/matlab/ceam.pyx` in two places, but that file never existed alongside this README — it was deleted in the same commit (`f8210c9`, nasa/cea#79) that introduced the "Legacy note" pointing at it.

## Changes
- Removed the "Legacy note" section in `source/bind/matlab/README.md` that described `ceam.pyx` as a legacy artifact.
- Reworded the nearby line about `CEA_ENABLE_BIND_MATLAB` to drop the "ceam" name entirely, since without the Legacy note it would be an unexplained reference.

## Testing
- Not run — docs-only change, no code affected.

## Compatibility / Numerical behavior
- [x] No expected changes to numerical results

---
Drafted with Claude's assistance
- The dangling reference and its origin commit were confirmed via `git log`/`git show --stat` prior to filing #22.
- The fix's scope was verified by re-grepping `.md`/`.rst` files repo-wide for "ceam" after the edit, confirming no references remain.


