### PR TITLE
perf: hoist sum(weights) out of per-species loops in mixture.f90

### DIFF
--- a/source/mixture.f90
+++ b/source/mixture.f90
@@ -752,13 +752,14 @@ contains
 
         ! Locals
         integer :: j
-        real(dp) :: hj, nj
+        real(dp) :: hj, nj, total_weight
 
         call check_array_len(size(weights), self%num_species, 'mixture_calc_enthalpy_single weights')
 
+        total_weight = sum(weights)
         h = 0.0d0
         do j = 1, self%num_species
-            nj = weights(j)/self%species(j)%molecular_weight/sum(weights)
+            nj = weights(j)/self%species(j)%molecular_weight/total_weight
             hj = self%species(j)%calc_enthalpy(temperature)
             h = h + nj*hj
         end do
@@ -778,14 +779,15 @@ contains
 
         ! Locals
         integer :: j
-        real(dp) :: hj, nj
+        real(dp) :: hj, nj, total_weight
 
         call check_array_len(size(weights), self%num_species, 'mixture_calc_enthalpy_multi weights')
         call check_array_len(size(temperatures), self%num_species, 'mixture_calc_enthalpy_multi temperatures')
 
+        total_weight = sum(weights)
         h = 0.0d0
         do j = 1, self%num_species
-            nj = weights(j)/self%species(j)%molecular_weight/sum(weights)
+            nj = weights(j)/self%species(j)%molecular_weight/total_weight
             hj = self%species(j)%calc_enthalpy(temperatures(j))
             h = h + nj*hj
         end do
@@ -841,14 +843,15 @@ contains
 
         ! Locals
         integer :: j
-        real(dp) :: sj, nj, n
+        real(dp) :: sj, nj, n, total_weight
 
         call check_array_len(size(weights), self%num_species, 'mixture_calc_entropy_single weights')
 
+        total_weight = sum(weights)
         n = 0.0d0
         s = 0.0d0
         do j = 1, self%num_species
-            nj = weights(j)/self%species(j)%molecular_weight/sum(weights)
+            nj = weights(j)/self%species(j)%molecular_weight/total_weight
             if (nj < 1e-35) cycle
             sj = self%species(j)%calc_entropy(temperature)
             if (self%is_condensed(j)) then
@@ -876,16 +879,17 @@ contains
 
         ! Locals
         integer :: j
-        real(dp) :: sj, nj, n
+        real(dp) :: sj, nj, n, total_weight
 
         call check_array_len(size(weights), self%num_species, 'mixture_calc_entropy_multi weights')
         call check_array_len(size(temperatures), self%num_species, 'mixture_calc_entropy_multi temperatures')
         call check_array_len(size(pressures), self%num_species, 'mixture_calc_entropy_multi pressures')
 
+        total_weight = sum(weights)
         n = 0.0d0
         s = 0.0d0
         do j = 1, self%num_species
-            nj = weights(j)/self%species(j)%molecular_weight/sum(weights)
+            nj = weights(j)/self%species(j)%molecular_weight/total_weight
             if (nj < 1e-35) cycle
             sj = self%species(j)%calc_entropy(temperatures(j))
             if (self%is_condensed(j)) then
@@ -974,13 +978,14 @@ contains
 
         ! Locals
         integer :: j
-        real(dp) :: cpj, nj
+        real(dp) :: cpj, nj, total_weight
 
         call check_array_len(size(weights), self%num_species, 'mixture_calc_frozen_cp_single weights')
 
+        total_weight = sum(weights)
         cp = 0.0d0
         do j = 1, self%num_species
-            nj  = weights(j)/self%species(j)%molecular_weight/sum(weights)
+            nj  = weights(j)/self%species(j)%molecular_weight/total_weight
             cpj = self%species(j)%calc_cp(temperature)
             cp  = cp + nj*cpj
         end do
@@ -1000,14 +1005,15 @@ contains
 
         ! Locals
         integer :: j
-        real(dp) :: cpj, nj
+        real(dp) :: cpj, nj, total_weight
 
         call check_array_len(size(weights), self%num_species, 'mixture_calc_frozen_cp_multi weights')
         call check_array_len(size(temperatures), self%num_species, 'mixture_calc_frozen_cp_multi temperatures')
 
+        total_weight = sum(weights)
         cp = 0.0d0
         do j = 1, self%num_species
-            nj  = weights(j)/self%species(j)%molecular_weight/sum(weights)
+            nj  = weights(j)/self%species(j)%molecular_weight/total_weight
             cpj = self%species(j)%calc_cp(temperatures(j))
             cp  = cp + nj*cpj
         end do
@@ -1027,13 +1033,14 @@ contains
 
         ! Locals
         integer :: j
-        real(dp) :: cvj, nj
+        real(dp) :: cvj, nj, total_weight
 
         call check_array_len(size(weights), self%num_species, 'mixture_calc_frozen_cv_single weights')
 
+        total_weight = sum(weights)
         cv = 0.0d0
         do j = 1, self%num_species
-            nj  = weights(j)/self%species(j)%molecular_weight/sum(weights)
+            nj  = weights(j)/self%species(j)%molecular_weight/total_weight
             cvj = self%species(j)%calc_cv(temperature)
             cv  = cv + nj*cvj
         end do
@@ -1053,14 +1060,15 @@ contains
 
         ! Locals
         integer :: j
-        real(dp) :: cvj, nj
+        real(dp) :: cvj, nj, total_weight
 
         call check_array_len(size(weights), self%num_species, 'mixture_calc_frozen_cv_multi weights')
         call check_array_len(size(temperatures), self%num_species, 'mixture_calc_frozen_cv_multi temperatures')
 
+        total_weight = sum(weights)
         cv = 0.0d0
         do j = 1, self%num_species
-            nj  = weights(j)/self%species(j)%molecular_weight/sum(weights)
+            nj  = weights(j)/self%species(j)%molecular_weight/total_weight
             cvj = self%species(j)%calc_cv(temperatures(j))
             cv  = cv + nj*cvj
         end do


### PR DESCRIPTION
## Summary

Hoist the per-call-invariant `sum(weights)` out of the per-species loops in `mixture.f90`, fixing an O(n) → O(n²) pattern. https://github.com/djkees/cea/issues/13

## Changes

In `source/mixture.f90`, added a `total_weight` local computed once via `sum(weights)` before each loop, replacing the `sum(weights)` call that was previously re-evaluated on every iteration, in:
- `mixture_calc_enthalpy_single` / `_multi`
- `mixture_calc_entropy_single` / `_multi`
- `mixture_calc_frozen_cp_single` / `_multi`
- `mixture_calc_frozen_cv_single` / `_multi`

Same `sum()` call, same floating-point summation order — just evaluated once per function call instead of once per species.

## Testing
```
cmake --build build-dev
./build-dev/source/cea_core_test.exe
python -m pytest source/bind/python/tests -q
```
- Fortran unit tests: `OK (122 tests)`, exit 0 — output byte-identical to the pre-fix build except the wall-clock timing line.
- Python binding tests: `113 passed`.
- Benchmark (standalone timing harness, not part of this diff): with a 162-species product mixture, calling each affected function 2,000,000 times showed ~5.7-10.3x speedups (enthalpy ~7.6x, entropy ~5.7x, frozen_cp ~10.3x, frozen_cv ~9.9x), with an identical result checksum before/after confirming no numerical change.

## Compatibility / Numerical behavior
- [x] No expected changes to numerical results

---

Drafted with Claude's assistance
- The recurring pattern and line numbers were confirmed by direct read of `mixture.f90`.
- Numerical equivalence was verified by rerunning the Fortran and Python test suites against both the pre-fix and post-fix builds and comparing output byte-for-byte (identical apart from timing), plus matching checksums in the benchmark at a larger species count.

