### PR TITLE
perf: hoist sum(weights) out of shock.f90 initialization loops

### DIFF
--- a/source/shock.f90
+++ b/source/shock.f90
@@ -616,6 +616,10 @@ contains
         call soln%eq_soln(idx)%constraints%set(type, T0, P0, &
             self%eq_solver%reactants%element_amounts_from_weights(weights))
 
+        ! Compute the molecular weight of the initial mixture
+        wm = sum(weights)
+        wm_k = wm
+
         ! Set the reactant weights as the species amount
         soln%eq_soln(idx)%converged = .true.
         soln%eq_soln(idx)%nj(:) = 0.0d0
@@ -623,7 +627,7 @@ contains
         do i = 1, self%eq_solver%num_reactants
             j = findloc(self%eq_solver%products%species_names, self%eq_solver%reactants%species_names(i), 1)
             if (j > 0) then
-                soln%eq_soln(idx)%nj(j) = (weights(i)/self%eq_solver%reactants%species(i)%molecular_weight)/sum(weights)
+                soln%eq_soln(idx)%nj(j) = (weights(i)/self%eq_solver%reactants%species(i)%molecular_weight)/wm
                 soln%eq_soln(idx)%ln_nj(j) = log(soln%eq_soln(idx)%nj(j))
             else
                 call log_warning("ShockSolver_solve_incident_frozen: Reactant not found in products.")
@@ -632,10 +636,6 @@ contains
 
         soln%eq_partials(idx)%dlnV_dlnP = -1.0d0
         soln%eq_partials(idx)%dlnV_dlnT = 1.0d0
-
-        ! Compute the molecular weight of the initial mixture
-        wm = sum(weights)
-        wm_k = wm
         soln%eq_soln(idx)%n = 1.0d0/wm
 
         ! Compute properties of the initial mixture
@@ -1127,7 +1127,7 @@ contains
             j = findloc(self%eq_solver%products%species_names, self%eq_solver%reactants%species_names(i), 1)
             if (j > 0) then
                 soln%eq_soln(1)%nj(j) = (reactant_weights(i)/ &
-                    self%eq_solver%reactants%species(i)%molecular_weight)/sum(reactant_weights)
+                    self%eq_solver%reactants%species(i)%molecular_weight)/wm
                 soln%eq_soln(1)%ln_nj(j) = log(soln%eq_soln(1)%nj(j))
             else
                 call log_warning("ShockSolver_solve_incident_frozen: Reactant not found in products.")


### PR DESCRIPTION
## Summary

Move the loop-invariant `sum(weights)` / `sum(reactant_weights)` calculation — its value doesn't change between iterations, so recomputing it every time is wasted work — out of two per-species initialization loops in `source/shock.f90`, computing it once beforehand instead. This matches the pattern already fixed in `mixture.f90` (#13 / #26). https://github.com/djkees/cea/issues/32

## Changes

In `source/shock.f90`:
- `ShockSolver_solve` (~line 1129-1130): replaced the per-iteration `sum(reactant_weights)` with the already-computed `wm` (computed once at line 1094, unchanged before use).
- `ShockSolver_solve_incident_frozen` (~line 619-637): moved `wm = sum(weights)` above the `do i = 1, num_reactants` loop and replaced the loop's inline `sum(weights)` with `wm`.

Same `sum()` call, same floating-point summation order — just evaluated once per initialization instead of once per reactant.

## Testing
```
cmake --build build-dev
ctest --test-dir build-dev --output-on-failure
python -m pytest source/bind/python/tests -q
python test/main_interface/test_main.py
```
- Fortran unit tests (ctest): 15/15 passed.
- Python binding tests: 113 passed.
- Legacy CLI validation: 14/14 passed, including `example7` (shock tube problem, exercises both `incd eql` and `incd froz` — i.e. both fixed code paths).
- Byte-identical output check: stashed the fix, rebuilt, and reran `example7` to get a pre-fix `.out` file, then restored the fix, rebuilt, and reran `example7` again — the two output files are byte-for-byte identical.

No standalone timing benchmark was added (unlike #26): unlike the `mixture.f90` functions, these loops aren't standalone functions that can be benchmarked in isolation — they're embedded in two large shock-solve initialization subroutines that run once per shock solve (not per Newton iteration) over a handful of reactants, so a micro-benchmark wouldn't show meaningful signal. This fix is about consistency with the established pattern, not measured performance gain, per the issue.

## Compatibility / Numerical behavior
- [x] No expected changes to numerical results

---

Drafted with Claude's assistance
- Both sites were confirmed by direct read of `ShockSolver_solve` and `ShockSolver_solve_incident_frozen`, including confirming `wm` is genuinely in scope and unmodified between its computation and use at each site.
- Numerical equivalence was verified by rerunning the Fortran, Python, and legacy CLI test suites, plus a direct byte-for-byte diff of the shock-tube example's output before and after the fix.
