### PR TITLE
Factor duplicated temperature-interval selection in thermo.f90

### DIFF
--- a/source/thermo.f90
+++ b/source/thermo.f90
@@ -128,11 +128,27 @@ contains
         end if
     end subroutine
 
+    elemental function st_select_interval(self, T) result(idx)
+        !! Select the index of the temperature-fit interval containing T
+        class(SpeciesThermo), intent(in) :: self
+        real(dp), intent(in) :: T
+        integer :: idx
+        integer :: i
+
+        idx = 1
+        do i = 1,self%num_intervals
+            if (T > self%T_fit(i, 1)) then
+                idx = i
+            end if
+        end do
+
+    end function
+
     elemental function st_calc_cv(self, T) result(cv)
         class(SpeciesThermo), intent(in) :: self
         real(dp), intent(in) :: T
         real(dp) :: cv
-        integer :: i, idx
+        integer :: idx
 
         if (.not. allocated(self%fits)) then
             cv = 0.0d0
@@ -140,12 +156,7 @@ contains
         end if
 
         ! Select temperature range
-        idx = 1
-        do i = 1,self%num_intervals
-            if (T > self%T_fit(i, 1)) then
-                idx = i
-            end if
-        end do
+        idx = st_select_interval(self, T)
 
         ! Evaluate selected fit
         cv = self%fits(idx)%calc_cv(T)
@@ -156,7 +167,7 @@ contains
         class(SpeciesThermo), intent(in) :: self
         real(dp), intent(in) :: T
         real(dp) :: cp
-        integer :: i, idx
+        integer :: idx
 
         if (.not. allocated(self%fits)) then
             cp = 0.0d0
@@ -164,12 +175,7 @@ contains
         end if
 
         ! Select temperature range
-        idx = 1
-        do i = 1,self%num_intervals
-            if (T > self%T_fit(i, 1)) then
-                idx = i
-            end if
-        end do
+        idx = st_select_interval(self, T)
 
         ! Evaluate selected fit
         cp = self%fits(idx)%calc_cp(T)
@@ -180,7 +186,7 @@ contains
         class(SpeciesThermo), intent(in) :: self
         real(dp), intent(in) :: T
         real(dp) :: u_R
-        integer :: i, idx
+        integer :: idx
 
         if (.not. allocated(self%fits)) then
             u_R = self%calc_enthalpy(T) - T
@@ -188,12 +194,7 @@ contains
         end if
 
         ! Select temperature range
-        idx = 1
-        do i = 1,self%num_intervals
-            if (T > self%T_fit(i, 1)) then
-                idx = i
-            end if
-        end do
+        idx = st_select_interval(self, T)
 
         ! Evaluate selected fit
         u_R = self%fits(idx)%calc_energy(T, log(T))
@@ -204,17 +205,12 @@ contains
         class(SpeciesThermo), intent(in) :: self
         real(dp), intent(in) :: T
         real(dp) :: h_R
-        integer :: i, idx
+        integer :: idx
 
         if (allocated(self%fits)) then
 
             ! Select temperature range
-            idx = 1
-            do i = 1,self%num_intervals
-                if (T > self%T_fit(i, 1)) then
-                    idx = i
-                end if
-            end do
+            idx = st_select_interval(self, T)
 
             ! Evaluate selected fit
             h_R = self%fits(idx)%calc_enthalpy(T, log(T))
@@ -229,7 +225,7 @@ contains
         class(SpeciesThermo), intent(in) :: self
         real(dp), intent(in) :: T
         real(dp) :: s_R
-        integer :: i, idx
+        integer :: idx
 
         if (.not. allocated(self%fits)) then
             s_R = 0.0d0
@@ -237,12 +233,7 @@ contains
         end if
 
         ! Select temperature range
-        idx = 1
-        do i = 1,self%num_intervals
-            if (T > self%T_fit(i, 1)) then
-                idx = i
-            end if
-        end do
+        idx = st_select_interval(self, T)
 
         ! Evaluate selected fit
         s_R = self%fits(idx)%calc_entropy(T, log(T))
@@ -253,7 +244,7 @@ contains
         class(SpeciesThermo), intent(in) :: self
         real(dp), intent(in) :: T
         real(dp) :: g
-        integer :: i, idx
+        integer :: idx
 
         if (.not. allocated(self%fits)) then
             g = self%calc_enthalpy(T)
@@ -261,12 +252,7 @@ contains
         end if
 
         ! Select temperature range
-        idx = 1
-        do i = 1,self%num_intervals
-            if (T > self%T_fit(i, 1)) then
-                idx = i
-            end if
-        end do
+        idx = st_select_interval(self, T)
 
         ! Evaluate selected fit
         g = self%fits(idx)%calc_gibbs_energy(T, log(T))
@@ -306,15 +292,10 @@ contains
         class(SpeciesThermo), intent(in) :: self
         real(dp), intent(in) :: T
         real(dp) :: dcv_dT
-        integer :: i, idx
+        integer :: idx
 
         ! Select temperature range
-        idx = 1
-        do i = 1,self%num_intervals
-            if (T > self%T_fit(i, 1)) then
-                idx = i
-            end if
-        end do
+        idx = st_select_interval(self, T)
 
         ! Evaluate selected fit
         dcv_dT = self%fits(idx)%calc_dcv_dT(T)
@@ -325,15 +306,10 @@ contains
         class(SpeciesThermo), intent(in) :: self
         real(dp), intent(in) :: T
         real(dp) :: dcp_dT
-        integer :: i, idx
+        integer :: idx
 
         ! Select temperature range
-        idx = 1
-        do i = 1,self%num_intervals
-            if (T > self%T_fit(i, 1)) then
-                idx = i
-            end if
-        end do
+        idx = st_select_interval(self, T)
 
         ! Evaluate selected fit
         dcp_dT = self%fits(idx)%calc_dcp_dT(T)
@@ -344,15 +320,10 @@ contains
         class(SpeciesThermo), intent(in) :: self
         real(dp), intent(in) :: T
         real(dp) :: du_dT
-        integer :: i, idx
+        integer :: idx
 
         ! Select temperature range
-        idx = 1
-        do i = 1,self%num_intervals
-            if (T > self%T_fit(i, 1)) then
-                idx = i
-            end if
-        end do
+        idx = st_select_interval(self, T)
 
         ! Evaluate selected fit
         du_dT = self%fits(idx)%calc_denergy_dT(T)
@@ -363,15 +334,10 @@ contains
         class(SpeciesThermo), intent(in) :: self
         real(dp), intent(in) :: T
         real(dp) :: dh_dT
-        integer :: i, idx
+        integer :: idx
 
         ! Select temperature range
-        idx = 1
-        do i = 1,self%num_intervals
-            if (T > self%T_fit(i, 1)) then
-                idx = i
-            end if
-        end do
+        idx = st_select_interval(self, T)
 
         ! Evaluate selected fit
         dh_dT = self%fits(idx)%calc_denthalpy_dT(T)
@@ -382,15 +348,10 @@ contains
         class(SpeciesThermo), intent(in) :: self
         real(dp), intent(in) :: T
         real(dp) :: ds_dT
-        integer :: i, idx
+        integer :: idx
 
         ! Select temperature range
-        idx = 1
-        do i = 1,self%num_intervals
-            if (T > self%T_fit(i, 1)) then
-                idx = i
-            end if
-        end do
+        idx = st_select_interval(self, T)
 
         ! Evaluate selected fit
         ds_dT = self%fits(idx)%calc_dentropy_dT(T)


### PR DESCRIPTION
## Summary

Factors the 11x duplicated temperature-interval-selection block in `source/thermo.f90` into a single shared helper function, as proposed in https://github.com/djkees/cea/issues/14.

## Changes

Added `st_select_interval(self, T) result(idx)`, an `elemental function` containing the same 6-line linear-scan loop that was previously duplicated in `st_calc_cv`, `st_calc_cp`, `st_calc_energy`, `st_calc_enthalpy`, `st_calc_entropy`, `st_calc_gibbs_energy`, and the five `st_calc_d*_dT` derivative functions. All 11 call sites now call `st_select_interval(self, T)` instead of inlining the loop.

This is a mechanical extraction: the loop body (initial value, comparison, bounds, update) is unchanged character-for-character, just moved into its own function.

## Testing
- `cmake --preset core-c -G Ninja` then `cmake --build build-core-c`, then `ctest --test-dir build-core-c --output-on-failure`: 14/14 tests pass, including the RP-1311 sample cases (`cea_bindc_rp1311_ex1` through `ex9`), which exercise the affected thermo calculations (`calc_cv`, `calc_cp`, `calc_enthalpy`, `calc_entropy`, etc.) across temperature ranges.

## Compatibility / Numerical behavior
- [x] No expected changes to numerical results

---

Drafted with Claude's assistance
- All 11 duplicate sites and the extraction were verified by direct read/edit of `thermo.f90`.
- Verified equivalence by inspection: the extracted loop body is unchanged from the original at each of the 11 sites (same initial value, comparison, bounds, and update).
- Verified by build/test: full `core-c` build succeeded and all 14 existing tests passed post-refactor, including sample cases that exercise every affected function.
