### PR TITLE
Factor duplicated solver-opts parsing into parse_solver_opts

### DIFF
--- a/source/bind/c/CMakeLists.txt
+++ b/source/bind/c/CMakeLists.txt
@@ -53,6 +53,14 @@ if (CEA_BUILD_TESTING)
         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
     )
 
+    add_executable(cea_bindc_solver_opts_validation tests/solver_opts_validation.c)
+    target_link_libraries(cea_bindc_solver_opts_validation PRIVATE cea::bindc)
+    add_test(
+        NAME cea_bindc_solver_opts_validation
+        COMMAND cea_bindc_solver_opts_validation
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    )
+
     add_executable(cea_bindc_rp1311_ex1 samples/rp1311_example1.c)
     target_link_libraries(cea_bindc_rp1311_ex1 PRIVATE cea::bindc)
     add_test(

--- a/source/bind/c/bindc.F90
+++ b/source/bind/c/bindc.F90
@@ -281,6 +281,70 @@ contains
         opts%truncation_width  = -1.0d0
     end function
 
+    subroutine parse_solver_opts(mptr_prod, opts, ierr, products, reactants, ions, transport, use_trace, insert)
+        ! Shared option decoding for cea_*_solver_create_with_options: reads the C
+        ! cea_solver_opts struct into the products/reactants mixtures, insert species
+        ! names, and boolean flags common to all solver types.
+        type(c_ptr), intent(in) :: mptr_prod
+        type(cea_solver_opts), intent(in) :: opts
+        integer(c_int), intent(out) :: ierr
+        type(Mixture), pointer, intent(out) :: products
+        type(Mixture), pointer, intent(out) :: reactants
+        logical, intent(out) :: ions, transport, use_trace
+        character(snl), allocatable, intent(out) :: insert(:)
+
+        ! Locals
+        type(c_ptr), pointer :: cinsert(:)
+        character(:), allocatable :: name
+        integer :: n
+
+        ierr = CEA_SUCCESS
+        call c_f_pointer(mptr_prod, products)
+
+        if (opts%ninsert < 0) then
+            ierr = CEA_INVALID_SIZE
+            return
+        end if
+        if (opts%ninsert > 0 .and. .not. c_associated(opts%insert)) then
+            ierr = CEA_INVALID_SIZE
+            return
+        end if
+
+        allocate(cinsert(opts%ninsert), insert(opts%ninsert))
+
+        ! Handle optional reactants mixture
+        if (c_associated(opts%reactants)) then
+            call c_f_pointer(opts%reactants, reactants)
+        else
+            nullify(reactants)
+        end if
+
+        ! Handle trace option
+        if (opts%trace > 0.0d0) then
+            use_trace = .true.
+        else
+            use_trace = .false.
+        end if
+
+        ! Convert ions from C bool to Fortran logical
+        ions = logical(opts%ions)
+        transport = logical(opts%transport)
+
+        ! Convert insert species names from C strings to Fortran strings
+        if (opts%ninsert > 0 .and. c_associated(opts%insert)) then
+            call c_f_pointer(opts%insert, cinsert, [opts%ninsert])
+
+            do n = 1, opts%ninsert
+                call c_copy(cinsert(n), name)
+                if (len(name) > snl) then
+                    ierr = CEA_INVALID_SIZE
+                    return
+                end if
+                insert(n) = name
+            end do
+        end if
+    end subroutine
+
     function cea_species_name_len(name_len) result(ierr) bind(c)
         integer(c_int) :: ierr
         integer(c_int), intent(out) :: name_len
@@ -1258,57 +1322,11 @@ contains
         type(EqSolver), pointer :: solver
         type(Mixture), pointer :: products
         type(Mixture), pointer :: reactants
-        type(c_ptr), pointer :: cinsert(:)
         character(snl), allocatable :: insert(:)
-        character(:), allocatable :: name
-        integer :: n
         logical :: ions, transport, use_trace
 
-        ierr = CEA_SUCCESS
-        call c_f_pointer(mptr_prod, products)
-
-        if (opts%ninsert < 0) then
-            ierr = CEA_INVALID_SIZE
-            return
-        end if
-        if (opts%ninsert > 0 .and. .not. c_associated(opts%insert)) then
-            ierr = CEA_INVALID_SIZE
-            return
-        end if
-
-        allocate(cinsert(opts%ninsert), insert(opts%ninsert))
-
-        ! Handle optional reactants mixture
-        if (c_associated(opts%reactants)) then
-            call c_f_pointer(opts%reactants, reactants)
-        else
-            nullify(reactants)
-        end if
-
-        ! Handle trace option
-        if (opts%trace > 0.0d0) then
-            use_trace = .true.
-        else
-            use_trace = .false.
-        end if
-
-        ! Convert ions from C bool to Fortran logical
-        ions = logical(opts%ions)
-        transport = logical(opts%transport)
-
-        ! Convert insert species names from C strings to Fortran strings
-        if (opts%ninsert > 0 .and. c_associated(opts%insert)) then
-            call c_f_pointer(opts%insert, cinsert, [opts%ninsert])
-
-            do n = 1, opts%ninsert
-                call c_copy(cinsert(n), name)
-                if (len(name) > snl) then
-                    ierr = CEA_INVALID_SIZE
-                    return
-                end if
-                insert(n) = name
-            end do
-        end if
+        call parse_solver_opts(mptr_prod, opts, ierr, products, reactants, ions, transport, use_trace, insert)
+        if (ierr /= CEA_SUCCESS) return
 
         allocate(solver)
         if (associated(reactants)) then
@@ -1546,57 +1564,11 @@ contains
         type(RocketSolver), pointer :: solver
         type(Mixture), pointer :: products
         type(Mixture), pointer :: reactants
-        type(c_ptr), pointer :: cinsert(:)
         character(snl), allocatable :: insert(:)
-        character(:), allocatable :: name
-        integer :: n
         logical :: ions, transport, use_trace
 
-        ierr = CEA_SUCCESS
-        call c_f_pointer(mptr_prod, products)
-
-        if (opts%ninsert < 0) then
-            ierr = CEA_INVALID_SIZE
-            return
-        end if
-        if (opts%ninsert > 0 .and. .not. c_associated(opts%insert)) then
-            ierr = CEA_INVALID_SIZE
-            return
-        end if
-
-        allocate(cinsert(opts%ninsert), insert(opts%ninsert))
-
-        ! Handle optional reactants mixture
-        if (c_associated(opts%reactants)) then
-            call c_f_pointer(opts%reactants, reactants)
-        else
-            nullify(reactants)
-        end if
-
-        ! Handle trace option
-        if (opts%trace > 0.0d0) then
-            use_trace = .true.
-        else
-            use_trace = .false.
-        end if
-
-        ! Convert ions from C bool to Fortran logical
-        ions = logical(opts%ions)
-        transport = logical(opts%transport)
-
-        ! Convert insert species names from C strings to Fortran strings
-        if (opts%ninsert > 0 .and. c_associated(opts%insert)) then
-            call c_f_pointer(opts%insert, cinsert, [opts%ninsert])
-
-            do n = 1, opts%ninsert
-                call c_copy(cinsert(n), name)
-                if (len(name) > snl) then
-                    ierr = CEA_INVALID_SIZE
-                    return
-                end if
-                insert(n) = name
-            end do
-        end if
+        call parse_solver_opts(mptr_prod, opts, ierr, products, reactants, ions, transport, use_trace, insert)
+        if (ierr /= CEA_SUCCESS) return
 
         allocate(solver)
         if (associated(reactants)) then
@@ -2376,57 +2348,11 @@ contains
         type(ShockSolver), pointer :: solver
         type(Mixture), pointer :: products
         type(Mixture), pointer :: reactants
-        type(c_ptr), pointer :: cinsert(:)
         character(snl), allocatable :: insert(:)
-        character(:), allocatable :: name
-        integer :: n
         logical :: ions, transport, use_trace
 
-        ierr = CEA_SUCCESS
-        call c_f_pointer(mptr_prod, products)
-
-        if (opts%ninsert < 0) then
-            ierr = CEA_INVALID_SIZE
-            return
-        end if
-        if (opts%ninsert > 0 .and. .not. c_associated(opts%insert)) then
-            ierr = CEA_INVALID_SIZE
-            return
-        end if
-
-        allocate(cinsert(opts%ninsert), insert(opts%ninsert))
-
-        ! Handle optional reactants mixture
-        if (c_associated(opts%reactants)) then
-            call c_f_pointer(opts%reactants, reactants)
-        else
-            nullify(reactants)
-        end if
-
-        ! Handle trace option
-        if (opts%trace > 0.0d0) then
-            use_trace = .true.
-        else
-            use_trace = .false.
-        end if
-
-        ! Convert ions from C bool to Fortran logical
-        ions = logical(opts%ions)
-        transport = logical(opts%transport)
-
-        ! Convert insert species names from C strings to Fortran strings
-        if (opts%ninsert > 0 .and. c_associated(opts%insert)) then
-            call c_f_pointer(opts%insert, cinsert, [opts%ninsert])
-
-            do n = 1, opts%ninsert
-                call c_copy(cinsert(n), name)
-                if (len(name) > snl) then
-                    ierr = CEA_INVALID_SIZE
-                    return
-                end if
-                insert(n) = name
-            end do
-        end if
+        call parse_solver_opts(mptr_prod, opts, ierr, products, reactants, ions, transport, use_trace, insert)
+        if (ierr /= CEA_SUCCESS) return
 
         allocate(solver)
         if (associated(reactants)) then
@@ -2650,57 +2576,11 @@ contains
         type(DetonSolver), pointer :: solver
         type(Mixture), pointer :: products
         type(Mixture), pointer :: reactants
-        type(c_ptr), pointer :: cinsert(:)
         character(snl), allocatable :: insert(:)
-        character(:), allocatable :: name
-        integer :: n
         logical :: ions, transport, use_trace
 
-        ierr = CEA_SUCCESS
-        call c_f_pointer(mptr_prod, products)
-
-        if (opts%ninsert < 0) then
-            ierr = CEA_INVALID_SIZE
-            return
-        end if
-        if (opts%ninsert > 0 .and. .not. c_associated(opts%insert)) then
-            ierr = CEA_INVALID_SIZE
-            return
-        end if
-
-        allocate(cinsert(opts%ninsert), insert(opts%ninsert))
-
-        ! Handle optional reactants mixture
-        if (c_associated(opts%reactants)) then
-            call c_f_pointer(opts%reactants, reactants)
-        else
-            nullify(reactants)
-        end if
-
-        ! Handle trace option
-        if (opts%trace > 0.0d0) then
-            use_trace = .true.
-        else
-            use_trace = .false.
-        end if
-
-        ! Convert ions from C bool to Fortran logical
-        ions = logical(opts%ions)
-        transport = logical(opts%transport)
-
-        ! Convert insert species names from C strings to Fortran strings
-        if (opts%ninsert > 0 .and. c_associated(opts%insert)) then
-            call c_f_pointer(opts%insert, cinsert, [opts%ninsert])
-
-            do n = 1, opts%ninsert
-                call c_copy(cinsert(n), name)
-                if (len(name) > snl) then
-                    ierr = CEA_INVALID_SIZE
-                    return
-                end if
-                insert(n) = name
-            end do
-        end if
+        call parse_solver_opts(mptr_prod, opts, ierr, products, reactants, ions, transport, use_trace, insert)
+        if (ierr /= CEA_SUCCESS) return
 
         allocate(solver)
         if (associated(reactants)) then

--- a/source/bind/c/tests/solver_opts_validation.c
+++ b/source/bind/c/tests/solver_opts_validation.c
@@ -1,0 +1,50 @@
+#include "cea.h"
+
+#include <stddef.h>
+
+int main(void)
+{
+    const cea_string reactants_names[] = {"N2 ", "CH4"};
+    const cea_string omitted[] = {""};
+    cea_mixture reac = NULL;
+    cea_mixture prod = NULL;
+    cea_eqsolver solver = NULL;
+    cea_solver_opts opts;
+
+    if (cea_init() != CEA_SUCCESS) return 1;
+    if (cea_mixture_create_w_ions(&reac, 2, reactants_names) != CEA_SUCCESS) return 2;
+    if (cea_mixture_create_from_reactants_w_ions(&prod, 2, reactants_names, 0, omitted) != CEA_SUCCESS) return 3;
+
+    // No reactants supplied: opts.reactants must be nullified rather than dereferenced.
+    cea_solver_opts_init(&opts);
+    if (cea_eqsolver_create_with_options(&solver, prod, opts) != CEA_SUCCESS) return 4;
+    cea_eqsolver_destroy(&solver);
+
+    // Negative ninsert is rejected.
+    cea_solver_opts_init(&opts);
+    opts.reactants = reac;
+    opts.ninsert = -1;
+    if (cea_eqsolver_create_with_options(&solver, prod, opts) != CEA_INVALID_SIZE) return 5;
+
+    // ninsert > 0 requires a non-null insert array.
+    cea_solver_opts_init(&opts);
+    opts.reactants = reac;
+    opts.ninsert = 2;
+    opts.insert = NULL;
+    if (cea_eqsolver_create_with_options(&solver, prod, opts) != CEA_INVALID_SIZE) return 6;
+
+    // Insert species names longer than species_name_len are rejected.
+    {
+        const cea_string insert[] = {"THIS_NAME_IS_WAY_TOO_LONG_FOR_A_SPECIES"};
+        cea_solver_opts_init(&opts);
+        opts.reactants = reac;
+        opts.ninsert = 1;
+        opts.insert = insert;
+        if (cea_eqsolver_create_with_options(&solver, prod, opts) != CEA_INVALID_SIZE) return 7;
+    }
+
+    cea_mixture_destroy(&prod);
+    cea_mixture_destroy(&reac);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary

Factors the ~45-line solver-options-parsing block, duplicated across all four `cea_*_solver_create_with_options` functions in `source/bind/c/bindc.F90`, into a single shared private subroutine. Pure refactor — no behavior or numerical change.

https://github.com/djkees/cea/issues/38

## Changes

- Adds `parse_solver_opts(mptr_prod, opts, ierr, products, reactants, ions, transport, use_trace, insert)` in `source/bind/c/bindc.F90`, decoding the C `cea_solver_opts` struct (size checks, `reactants`/`trace`/`ions`/`transport` conversion, insert-species string copy) exactly as the four call sites did before.
- Replaces the duplicated block in `cea_eqsolver_create_with_options`, `cea_rocket_solver_create_with_options`, `cea_shock_solver_create_with_options`, and `cea_detonation_solver_create_with_options` with a call to the shared helper plus `if (ierr /= CEA_SUCCESS) return`.
- Adds `source/bind/c/tests/solver_opts_validation.c`, a regression test covering the branches of this block not already exercised by existing samples (`rp1311_example2.c`, `shock_last_valid.c`): the no-reactants path, `ninsert < 0`, `ninsert > 0` with a null `insert` array, and an oversized insert-species name — each asserting the expected `cea_err` return.

## Testing
- `cmake --build build-core-c` — clean build.
- `ctest --test-dir build-core-c --output-on-failure` — 15/15 passed, including the new `cea_bindc_solver_opts_validation` test and the existing C-binding samples that exercise `*_create_with_options` (`cea_bindc_rp1311_ex1/ex2`, `cea_bindc_shock_last_valid`).
- Before finalizing, also built and ran a throwaway test (not included in this PR) that called all four `*_create_with_options` functions with valid options/insert species, confirming identical `CEA_SUCCESS` behavior across all four call sites post-refactor.

## Compatibility / Numerical behavior
- [x] No expected changes to numerical results

---
Drafted with Claude's assistance
- All four duplicate-block call sites and their exact contents were confirmed by direct read of `bindc.F90` before and after the refactor.
- The diff was verified to be structurally identical (same checks, same conversions, same error codes) at each of the four sites, not just the first.
- Verified by an actual build (`cmake --build`) and full `ctest` run, not just visual inspection — see Testing above.

