### PR TITLE
Smooth-gate transport-species screening for trace species

### DIFF
--- a/source/equilibrium.f90
+++ b/source/equilibrium.f90
@@ -5168,7 +5168,10 @@ contains
         logical, allocatable :: selected_species(:)
 
         logical :: frozen_transport_only
-        real(dp), parameter :: transport_log_cutoff = 25.328436d0
+        real(dp) :: ln_n                      ! log of total gas moles, for the trace-species reactivation threshold
+        real(dp) :: ln_threshold              ! Species-amount activity threshold (tsize/esize-based)
+        real(dp) :: nj_eff_tmp                ! Smooth-truncation-aware effective species amount
+        logical :: ion_species                ! True if gas species is charged and ions are active
 
         frozen_transport_only = .false.
         if (present(frozen_shock)) frozen_transport_only = frozen_shock
@@ -5208,13 +5211,38 @@ contains
         if (eq_solver%ions) max_elem_idx = max_elem_idx - 1
         nj_el = 0.0d0
 
+        ! Revive gas species already zeroed for reporting if they remain active by the
+        ! same tsize/esize threshold (and smooth_truncation gate) used elsewhere in the solve,
+        ! so trace-species screening for the transport-species list stays consistent
+        ! with the rest of the smooth-truncation machinery.
+        !
+        ! NOTE: In the typical converged path, eq_soln%nj(i) was already zeroed by
+        ! compute_reported_nj using the far more permissive log_min (~-87) floor, while
+        ! tsize/esize offsets are only ~18-32 -- so in practice this loop rarely has any
+        ! species to revive; it mainly matters in the singular-matrix fallback path,
+        ! where nj is still gated directly by tsize. A future, tighter or user-configurable
+        ! reporting floor (replacing the fixed log_min) would make this loop load-bearing
+        ! far more often.
+        ln_n = log(eq_soln%n)
         do i = 1, ng
-            ! TODO(smooth_truncation): transport species screening currently uses hard-zero semantics.
-            ! Revisit whether smooth mode should use a practical-zero cutoff instead.
+            ! Only species already reported as zero are candidates for revival here;
+            ! species still positive keep whatever value they already have.
             if (eq_soln%nj(i) <= 0.0d0) then
-                if (eq_soln%ln_nj(i) - log(eq_soln%n) + transport_log_cutoff > 0.0d0) then
-                    eq_soln%nj(i) = exp(eq_soln%ln_nj(i))
-                end if
+                ! Ions get the looser esize threshold instead of tsize, matching every
+                ! other activity check in this file
+                ion_species = eq_solver%ions .and. eq_solver%active_ions .and. ne > 0 .and. A(i, ne) /= 0.0d0
+                ! Species-amount threshold below which species i is treated as inactive:
+                ! ln_threshold = ln_n - tsize (or - esize for ions).
+                ln_threshold = gas_amount_ln_threshold(ln_n, eq_solver%tsize, eq_solver%esize, ion_species)
+                ! Hard mode: nj_eff_tmp is exp(ln_nj) if above threshold, else exactly 0.
+                !
+                ! Smooth mode: nj_eff_tmp is exp(ln_nj) scaled by a logistic gate that ramps
+                ! from 0 to 1 across truncation_width, rather than snapping on at the threshold.
+                call compute_nj_effective(eq_soln%ln_nj(i), ln_threshold, eq_solver%smooth_truncation, &
+                                          eq_solver%truncation_width, nj_eff_tmp)
+                ! Only overwrite nj(i) when the gate actually revives it; never write an
+                ! explicit 0.0 here so an already-reported 0 is left untouched.
+                if (nj_eff_tmp > 0.0d0) eq_soln%nj(i) = nj_eff_tmp
             end if
         end do
 

--- a/source/equilibrium_test.pf
+++ b/source/equilibrium_test.pf
@@ -4095,6 +4095,11 @@ contains
 
     @test
     subroutine test_equilibrium_transport_ch4_o2_smooth_truncation
+        ! Exercises the transport-species screening in compute_transport_properties under
+        ! smooth_truncation: trace species are revived via compute_nj_effective's smooth gate
+        ! (consistent with the rest of the smooth-truncation machinery) instead of always being
+        ! screened with a hard-zero check, so this confirms that path still yields physically
+        ! sane transport properties.
         type(Mixture) :: products
         type(Mixture) :: reactants
         type(EqSolver) :: solver
@@ -4117,6 +4122,102 @@ contains
 
         @assertTrue(solution%converged)
         @assertTrue(solution%T > 0.0d0)
+        @assertTrue(solution%viscosity > 0.0d0)
+        @assertTrue(solution%conductivity_fr > 0.0d0)
+        @assertTrue(solution%conductivity_eq > 0.0d0)
+        @assertTrue(solution%pr_fr > 0.0d0)
+        @assertTrue(solution%pr_eq > 0.0d0)
+    end subroutine
+
+    @test
+    subroutine test_transport_screening_smooth_gate_at_threshold
+        ! Isolated regression test for the equilibrium.f90 fix to the transport-species
+        ! screening loop in compute_transport_properties (issue djkees/cea#11).
+        !
+        ! A full second solve with smooth_truncation on would follow a different Newton
+        ! path than the hard-mode solve (smooth_truncation affects many other call sites
+        ! in the solve, not just this loop), so comparing two independent end-to-end
+        ! solves cannot isolate this one loop's behavior -- confirmed by checking that
+        ! such a comparison still passed against the pre-fix code. Instead, solve once,
+        ! then call compute_transport_properties directly on the same converged solution
+        ! with one species' ln_nj forced exactly to its activity threshold and nj forced
+        ! to zero -- first with smooth_truncation off, then on. The only thing that
+        ! differs between the two direct calls is the gate itself.
+        type(Mixture) :: products
+        type(Mixture) :: reactants
+        type(EqSolver) :: solver
+        type(EqSolution) :: soln
+        character(:), allocatable :: product_names(:)
+        real(dp) :: h_reac, p_reac, weights(2)
+        real(dp) :: ln_threshold
+        integer :: idx(1), i
+
+        reactants = Mixture(all_thermo, ['CH4', 'O2 '])
+        product_names = reactants%get_products(all_thermo)
+        products = Mixture(all_thermo, product_names)
+
+        solver = EqSolver(products, reactants, all_transport=all_transport)
+        soln = EqSolution(solver)
+
+        weights = reactants%weights_from_of([0.0d0, 1.0d0], [1.0d0, 0.0d0], 2.6d0)
+        h_reac = reactants%calc_enthalpy(weights, [298.15d0, 298.15d0])/R
+        p_reac = psi_to_bar(1000.0d0)
+
+        call solver%solve(soln, 'hp', h_reac, p_reac, weights)
+        @assertTrue(soln%converged)
+
+        ! Perturb the smallest-amount gas species so overwriting it doesn't disturb
+        ! the dominant-species mass balance used elsewhere in the routine.
+        idx = minloc(soln%nj(:solver%num_gas))
+        i = idx(1)
+
+        ln_threshold = log(soln%n) - solver%tsize
+        soln%nj(i) = 0.0d0
+        soln%ln_nj(i) = ln_threshold
+
+        solver%smooth_truncation = .false.
+        call compute_transport_properties(solver, soln)
+        @assertEqual(0.0d0, soln%nj(i))
+
+        solver%smooth_truncation = .true.
+        call compute_transport_properties(solver, soln)
+        @assertTrue(soln%nj(i) > 0.0d0)
+    end subroutine
+
+    @test
+    subroutine test_equilibrium_transport_ionized_smooth_truncation
+        ! Exercises the ion-aware branch (esize threshold instead of tsize) of the
+        ! transport-species screening loop, combined with smooth_truncation. This
+        ! combination -- ions + transport + smooth_truncation together -- was not
+        ! otherwise covered: test_ionized_smooth_truncation exercises ions with
+        ! smooth_truncation but without transport enabled, so it never reaches
+        ! compute_transport_properties at all.
+        type(Mixture) :: products
+        type(Mixture) :: reactants
+        type(EqSolver) :: solver
+        type(EqSolution) :: soln
+        character(snl), allocatable :: product_names(:)
+        real(dp) :: p_reac, t_reac, weights(1)
+
+        reactants = Mixture(all_thermo, ['Air'], ions=.true.)
+        product_names = reactants%get_products(all_thermo, omit=["C(gr)"])
+        products = Mixture(all_thermo, product_names, ions=.true.)
+
+        solver = EqSolver(products, reactants, ions=.true., all_transport=all_transport, smooth_truncation=.true.)
+        soln = EqSolution(solver)
+
+        weights = [1.0d0]
+        t_reac = 5000.0d0
+        p_reac = 0.0101325d0
+
+        call solver%solve(soln, 'tp', t_reac, p_reac, weights)
+
+        @assertTrue(soln%converged)
+        @assertTrue(soln%viscosity > 0.0d0)
+        @assertTrue(soln%conductivity_fr > 0.0d0)
+        @assertTrue(soln%conductivity_eq > 0.0d0)
+        @assertTrue(soln%pr_fr > 0.0d0)
+        @assertTrue(soln%pr_eq > 0.0d0)
     end subroutine
 
     @test


### PR DESCRIPTION
## Summary

Transport-species screening in `compute_transport_properties` used a hardcoded, always-hard-zero cutoff to decide whether to revive a trace gas species for the transport-species list, ignoring `smooth_truncation` entirely and drifting out of sync with a custom `trace` value. This replaces it with the same `tsize`/`esize` threshold and `compute_nj_effective` smooth gate used everywhere else in the solve.

https://github.com/djkees/cea/issues/11

## Changes

- `source/equilibrium.f90`: replaced the hardcoded `transport_log_cutoff = 25.328436d0` constant and its hard `nj(i) <= 0.0d0` step check with `gas_amount_ln_threshold` (ion-aware, using `tsize`/`esize`) and `compute_nj_effective` (respects `smooth_truncation`/`truncation_width`), matching the pattern used at every other activity-threshold check in this file. Added a comment noting why this loop rarely has anything to revive in the common converged path (species are already screened by the far more permissive `log_min` floor before this loop runs) and when it actually matters (the singular-matrix fallback path, or a future tighter/configurable reporting floor).
- `source/equilibrium_test.pf`: strengthened the existing `test_equilibrium_transport_ch4_o2_smooth_truncation` stub with transport-property assertions; added `test_equilibrium_transport_ionized_smooth_truncation` (ions + transport + smooth_truncation together, not otherwise covered); added `test_transport_screening_smooth_gate_at_threshold`, which isolates the changed loop directly by calling `compute_transport_properties` twice on the same converged solution with one species pinned exactly at its activity threshold — once with `smooth_truncation` off, once on.

## Testing
- `cmake --build build-dev --target cea_core_test -j4 && ./build-dev/source/cea_core_test.exe` — full 124-test suite (122 pre-existing + 2 new) passes.
- Verified `test_transport_screening_smooth_gate_at_threshold` actually isolates this change: temporarily reverted just `equilibrium.f90` (keeping the new test) and reran — that one test failed as expected (`equilibrium_test.pf:4184`, the smooth-mode revival assertion), with every other test still passing. Restored the fix and reconfirmed all 124 pass.
- Ran the same CH4/O2 and ionized Li/F2 chamber-state cases end-to-end with `smooth_truncation` on vs. off through the Python bindings: converged results agree to 1e-8–1e-16 relative (ordinary solve-path noise, not a discrepancy), with a ~4-45% per-solve timing overhead for smooth mode depending on mixture size, consistent with it being an opt-in, numerically-smoother reformulation rather than a different physical model.

## Compatibility / Numerical behavior
- [ ] No expected changes to numerical results
- [x] Expected changes (explain and provide validation)

For default settings (no custom `trace`, `smooth_truncation` off), behavior is unchanged: `tsize` equals the old hardcoded constant's value by coincidence at convergence, and the full pre-existing test suite (including several exact-reference-value regression tests) passes unmodified. Real behavior changes are scoped to: (1) a custom `trace` value, which the old code silently ignored for this one loop; (2) ionized mixtures, which now get the same looser `esize` threshold used everywhere else instead of a flat cutoff; (3) `smooth_truncation=True` runs, where deep-trace species (near the `log_min` reporting floor) are now revived to a small nonzero amount instead of an exact hard zero — validated directly by the new isolated test, and shown not to meaningfully affect aggregate transport properties in two realistic end-to-end cases.

---

Drafted with Claude's assistance.
- The root cause (a hardcoded constant that happens to equal the default `xsize`, and a `smooth_truncation` flag ignored entirely by this one loop) was found by direct reading of `equilibrium.f90` and tracing where `eq_soln%nj` is populated before this loop runs (`compute_reported_nj` / `log_min`), not taken from the issue text alone.
- Numerical claims were independently verified: full existing test suite reruns, an isolated Fortran-level test that was checked to fail against the pre-fix code and pass against the fix, and end-to-end Python-binding comparisons (CH4/O2 and ionized Li/F2 cases) with on/off timing and per-species `nj` diffs, not just aggregate outputs.

## Suggested changelog entry (for `CHANGELOG.md`, left to the maintainer to place)

> ### Fixed
> - Transport-species screening in `compute_transport_properties` now uses the same `tsize`/`esize` activity threshold and `smooth_truncation` gate as the rest of the equilibrium solve, instead of a hardcoded cutoff that only coincidentally matched the default `trace` setting and always applied a hard zero/nonzero step. Results are unchanged for default settings; a custom `trace` value or ionized mixtures may now include slightly different trace species in transport-property output, and `smooth_truncation=True` runs revive trace species continuously instead of via a step.

