### PR TITLE
Remove unused P0 argument from ShockSolver_solve_reflected

### DIFF
--- a/source/shock.f90
+++ b/source/shock.f90
@@ -725,7 +725,7 @@ contains
 
     end subroutine
 
-    subroutine ShockSolver_solve_reflected(self, soln, weights, T0, P0)
+    subroutine ShockSolver_solve_reflected(self, soln, weights, T0)
         ! Solve the reflected shock conditions
 
         ! Arguments
@@ -733,7 +733,6 @@ contains
         class(ShockSolution), intent(inout) :: soln
         real(dp), intent(in) :: weights(:)
         real(dp), intent(in) :: T0                     ! Initial reactant temperature [K]
-        real(dp), intent(in) :: P0                     ! Initial reactant pressure [bar]
 
         ! Locals
         integer :: idx  ! Solution index for the incident conditions
@@ -758,7 +757,6 @@ contains
         real(dp), parameter :: T_gas_max = 20000.d0  ! Max gas temperature in the thermo database [K]
 
         ! Initialize
-        if (.false.) print *, P0
         idx = 3
         G = 0.0d0  ! Reset the matrix
         soln%converged = .false.
@@ -1158,7 +1156,7 @@ contains
             if (reflected_frozen_) then
                 call self%solve_reflected_frozen(soln, reactant_weights, T0, P0)
             else  ! Equilibrium
-                call self%solve_reflected(soln, reactant_weights, T0, P0)
+                call self%solve_reflected(soln, reactant_weights, T0)
             end if
             if (soln%eq_soln(3)%T <= 0.0d0) then
                 return


### PR DESCRIPTION
## Summary
`ShockSolver_solve_reflected` in shock.f90 took a `P0` dummy argument (Fortran's term for a subroutine's declared parameter) it never used for anything except a dead `if (.false.) print *, P0` statement, apparently there only to silence gfortran's `-Wunused-dummy-argument` warning under `-Wall`.

https://github.com/djkees/cea/issues/17

## Changes
- Dropped `P0` from the `ShockSolver_solve_reflected` signature and declaration in source/shock.f90.
- Removed the `if (.false.) print *, P0` workaround.
- Updated the single call site (`ShockSolver_solve`) to stop passing `P0`.

`T0` was left alone — it's genuinely used later in the subroutine for the sound-speed calculation.

## Testing
- `ctest --output-on-failure` in a Debug (`dev` preset, `-Wall -Wextra`) build: 15/15 passed, including `cea_core_test` (runs `shock_test.pf`) and `cea_bindc_shock_last_valid`.
- `make py-rebuild && pytest source/bind/python/tests -q`: 113 passed, including `test_shock_conservation.py` and `test_shock_last_valid.py`, which exercise `ShockSolver_solve_reflected` directly.
- Confirmed the Debug build of shock.f90 produces zero warnings after the change (previously the dead print was there specifically to avoid an unused-dummy-argument warning; removing the argument itself avoids it just as well).

## Compatibility / Numerical behavior
- [x] No expected changes to numerical results

Pure signature cleanup — no logic touched, no numerical behavior change expected or observed.

---
Drafted with Claude's assistance
- The single-reference claim for `P0` was verified by reading the full subroutine body and grepping for other uses in shock.f90.
- Verified the fix by rebuilding both the Fortran core (Debug preset with `-Wall -Wextra`) and the Python bindings, and running the full existing test suite (ctest + pytest) rather than relying on inspection alone.
