### PR TITLE
Make test_main.py exit non-zero on comparison failure

### DIFF
--- a/test/main_interface/test_main.py
+++ b/test/main_interface/test_main.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import subprocess
+import sys
 import warnings
 import csv
 from pathlib import Path
@@ -580,3 +581,5 @@ with open("test_results.csv", "w", newline="") as csv_file:
     writer.writerow(["test_name", "value_type", "variable", "value", "reference", "abs_error", "rel_error"])
     for row in zip(test_names_csv, value_type, variable, value, reference, abs_error, rel_error):
         writer.writerow(row)
+
+sys.exit(0 if passed_count == num_tests else 1)


### PR DESCRIPTION
## Summary

`test/main_interface/test_main.py` never signaled failure via its process exit code — it always exited 0 regardless of how many numeric comparisons failed, so it couldn't gate CI even if wired in.

https://github.com/djkees/cea/issues/20

## Changes

- Import `sys`.
- After the results are written to `test_results.csv`, exit with `sys.exit(0 if passed_count == num_tests else 1)`.

This is part (a) from the linked issue — the small, self-contained piece. Part (b), actually wiring the script into a CI job, is tracked separately in https://github.com/djkees/cea/issues/85 since it needs a maintainer decision on job placement and whether it's a required check.

## Testing
- Ran the full suite against a local `build-dev/source/cea.exe` build: `14/14 tests passed`, exit code `0`.
- To confirm the exit code actually reflects failures (not just passes), temporarily edited one reference value in `example1.out` outside tolerance to force a mismatch, then reran: `13/14 tests passed`, exit code `1`. This edit was local-only and never committed — reverted with `git checkout` before committing the fix, and `git status` confirmed clean afterward.

## Compatibility / Numerical behavior
- [x] No expected changes to numerical results

---
Drafted with Claude's assistance
- The exit-code gap was confirmed by reading the full script and grepping for `sys.exit`/`assert`/`raise SystemExit`/bare `exit(` (zero matches) in the original issue investigation.
- The fix itself was verified by actually running the suite pass/fail, as described in Testing above, not just read for correctness.
