### PR TITLE
Dedupe redundant cp dot_product in EqSolver post-processing

### DIFF
--- a/source/bind/python/tests/test_reuse_solution.py
+++ b/source/bind/python/tests/test_reuse_solution.py
@@ -71,3 +71,39 @@ def test_issue42_reused_eqsolution_matches_fresh():
     assert reuse_soln.T == pytest.approx(fresh_soln.T, rel=1.0e-6)
     assert reuse_soln.n == pytest.approx(fresh_soln.n, rel=1.0e-6)
     assert np.allclose(reuse_soln.nj, fresh_soln.nj, rtol=1.0e-6, atol=1.0e-12)
+
+
+def test_reused_eqsolution_cp_matches_fresh():
+    # Regression test for the EqSolver_post_process cp_fr/cp_eq dedup
+    # (djkees/cea#30): a reused EqSolution starts each solve with the
+    # cp_fr/cp_eq values left over from the previous solve, so the
+    # `< 1.d-10` guards that skip recomputation must still be evaluated
+    # independently per field rather than short-circuited together.
+    reac_names = ["O2", "C2H4"]
+    reac = cea.Mixture(reac_names)
+    prod = cea.Mixture(reac_names, products_from_reactants=True)
+
+    p1 = 60.0
+    h1 = 129.92208593485029
+    p2 = 95.242559745142628
+    t2 = 3585.9524742656135
+
+    wo = np.array((1.0, 0.0))
+    wf = np.array((0.0, 1.0))
+    of_ratio = reac.weight_eq_ratio_to_of_ratio(wo, wf, 0.4)
+    weights = reac.of_ratio_to_weights(wo, wf, of_ratio)
+
+    solver = cea.EqSolver(prod, reactants=reac)
+
+    reuse_soln = cea.EqSolution(solver)
+    solver.solve(reuse_soln, cea.HP, h1, p1, weights)
+    assert reuse_soln.converged
+    solver.solve(reuse_soln, cea.TP, t2, p2, weights)
+    assert reuse_soln.converged
+
+    fresh_soln = cea.EqSolution(solver)
+    solver.solve(fresh_soln, cea.TP, t2, p2, weights)
+    assert fresh_soln.converged
+
+    assert reuse_soln.cp_fr == pytest.approx(fresh_soln.cp_fr, rel=1.0e-6)
+    assert reuse_soln.cp_eq == pytest.approx(fresh_soln.cp_eq, rel=1.0e-6)

--- a/source/equilibrium.f90
+++ b/source/equilibrium.f90
@@ -2305,6 +2305,8 @@ contains
         logical :: computed_partials_
         real(dp) :: entropy_sum
         real(dp) :: log_p_over_n
+        real(dp) :: cp_dot_nj
+        logical :: need_cp_fr, need_cp_eq
 
         computed_partials_ = .false.
         if (present(computed_partials)) computed_partials_ = computed_partials
@@ -2328,10 +2330,11 @@ contains
         soln%entropy = entropy_sum * R / 1.d3
         soln%gibbs_energy = (soln%enthalpy - soln%T*soln%entropy)
 
-        if (soln%cp_fr < 1.d-10) soln%cp_fr = dot_product(soln%thermo%cp, soln%nj) * R / 1.d3
-        if (.not. computed_partials_ .and. soln%cp_eq < 1.d-10) then
-            soln%cp_eq = dot_product(soln%thermo%cp, soln%nj) * R / 1.d3
-        end if
+        need_cp_fr = soln%cp_fr < 1.d-10
+        need_cp_eq = .not. computed_partials_ .and. soln%cp_eq < 1.d-10
+        if (need_cp_fr .or. need_cp_eq) cp_dot_nj = dot_product(soln%thermo%cp, soln%nj)
+        if (need_cp_fr) soln%cp_fr = cp_dot_nj * R / 1.d3
+        if (need_cp_eq) soln%cp_eq = cp_dot_nj * R / 1.d3
 
         ! Calculate molecular weights
         soln%M = 1.0d0/soln%n
@@ -4703,6 +4706,7 @@ contains
         ! Locals
         real(dp), allocatable :: J(:,:)
         real(dp) :: nj_solid ! Temporary variables for condensed species
+        real(dp) :: cp_dot_nj
         integer :: ng, ne, nc, na, ierr, i, idx, liq_rank
         integer, allocatable :: active_idx(:)
         real(dp), pointer :: nj(:), nj_g(:)     ! Total/gas species concentrations [kmol-per-kg]
@@ -4733,8 +4737,9 @@ contains
         self%cp_eq = 0.0d0
 
         ! Term 4: ∑_j^ns n_j*Cp_j/R
-        self%cp_eq = self%cp_eq + dot_product(soln%thermo%cp, soln%nj)
-        soln%cp_fr = dot_product(soln%thermo%cp, soln%nj)*(R/1.d3)
+        cp_dot_nj = dot_product(soln%thermo%cp, soln%nj)
+        self%cp_eq = self%cp_eq + cp_dot_nj
+        soln%cp_fr = cp_dot_nj*(R/1.d3)
 
         ! If both solid and liquid present, temporarily remove liquid to prevent singular matrix
         if (soln%j_sol /= 0) then


### PR DESCRIPTION
## Summary
Fixes the duplicate `dot_product(soln%thermo%cp, soln%nj)` calls in `source/equilibrium.f90` identified in https://github.com/djkees/cea/issues/30. Same arguments, nothing mutates them in between, so each site computed the identical value twice.

## Changes
- `EqPartials_compute_partials`: computes the dot product once into a local `cp_dot_nj` and reuses it for `self%cp_eq` and `soln%cp_fr`.
- `EqSolver_post_process`: the two guarded assignments (`cp_fr < 1e-10`, and `cp_eq < 1e-10 .and. .not. computed_partials_`) are independent conditions, so hoisting the dot product unconditionally would have computed it even when neither branch needs it — a common case in practice, since `compute_partials` already sets both fields before `post_process` runs whenever partials/transport are requested. Instead, both guards are evaluated into `need_cp_fr`/`need_cp_eq` locals, the dot product is computed once only if either is true, and reused in both branches. This preserves the exact original skip/compute behavior while deduping the common "both true" case (a fresh solve with no partials requested).

## Testing
- `cmake --build build-dev` — clean build, no new warnings.
- `ctest --test-dir build-dev --output-on-failure` — 15/15 passed.
- `python -m pytest source/bind/python/tests -q` — 115/115 passed (114 existing + 1 new regression test).
- `python test/main_interface/test_main.py` — 14/14 passed (byte-comparison against reference `.out` files across equilibrium, rocket, shock, and detonation examples).

Added `test_reused_eqsolution_cp_matches_fresh` to `source/bind/python/tests/test_reuse_solution.py`, following the existing `test_issue42_reused_eqsolution_matches_fresh` pattern: it solves into a reused `EqSolution` twice (so `cp_fr`/`cp_eq` carry stale values from the first solve into the second solve's guards) and checks the result matches a fresh solve — directly exercising the guard logic touched by this change.

## Compatibility / Numerical behavior
- [x] No expected changes to numerical results

Same summation, same order, bitwise-identical result by construction — this only removes a redundant recomputation, it does not change what gets computed or in what order.

---
Drafted with Claude's assistance
- Both duplicate-computation sites were confirmed by direct read of `EqPartials_compute_partials` and `EqSolver_post_process`, checking nothing mutates `soln%thermo%cp`/`soln%nj` between the duplicate calls (per the linked issue).
- Verified the `post_process` guard refactor preserves real-world skip behavior by instrumenting the guard with a debug print, rebuilding, and tracing actual `need_cp_fr`/`need_cp_eq` values through a reused-`EqSolution` scenario before removing the instrumentation.
- Full local build + test suite rerun (Fortran ctest, Python pytest, and the legacy CLI byte-comparison suite) confirmed identical results before and after the change, as detailed in Testing above.
