### PR TITLE
Bump CMakePresets.json schema version to 2 for CMake Tools compatibility

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,8 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "cmakeMinimumRequired": {
     "major": 3,
-    "minor": 19,
+    "minor": 20,
     "patch": 0
   },
   "configurePresets": [


### PR DESCRIPTION
## Summary

Bump `CMakePresets.json`'s schema `version` from 1 to 2 (and the accompanying `cmakeMinimumRequired.minor` from 19 to 20). Schema version 1 is deprecated by CMake, and VS Code's CMake Tools extension warns / can fail to load presets correctly against it.

## Changes

- `CMakePresets.json`: `version: 1 -> 2`, `cmakeMinimumRequired.minor: 19 -> 20`. No preset behavior changes — schema v2 is backward compatible with the fields already in use here.

## Testing

- Confirmed the fields already present in `CMakePresets.json` (`configurePresets` keys in use) are valid under CMake's schema v2 by checking against CMake's presets schema documentation. Did not execute a full local build of every preset as part of this PR — the change is a metadata-only version bump with no new or altered preset fields, so no build-behavior change is expected.

## Compatibility / Numerical behavior
- [x] No expected changes to numerical results
- [ ] Expected changes (explain and provide validation)

Build-configuration-only change; no solver, binding, or data-file code is touched.

---

Drafted with Claude's assistance.
- The schema version bump was checked against CMake's own presets schema documentation (v2 field/version requirements) rather than assumed compatible.
