### PR TITLE
Fix eq_solve's HP/SP/UV state1 missing /R conversion

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,8 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "cmakeMinimumRequired": {
     "major": 3,
-    "minor": 19,
+    "minor": 20,
     "patch": 0
   },
   "configurePresets": [

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,12 @@ Changes that improve readability, documentation, or interfaces are often welcome
    - `dev-intel` – Intel ifort with all bindings
    - `dev-ub-hunt` – GNU with undefined behavior detection (for advanced debugging)
 
+   These presets lock the Unix Makefiles generator and target GNU toolchains,
+   so they fail outright on Windows (`CMAKE_MAKE_PROGRAM is not set`). On
+   Windows, follow the explicit generator flow in the [Windows
+   Notes](https://nasa.github.io/cea/installation.html#windows-notes) section
+   of the installation guide instead of the preset commands below.
+
 3. **Configure and build**
    ```bash
    cmake --preset dev

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,19 +143,28 @@ At minimum, contributors should verify that:
 CEA uses pFUnit (part of the Goddard Fortran Ecosystem) for unit testing. Tests are enabled via the `CEA_BUILD_TESTING` CMake option.
 
 **Prerequisites:**
-1. Clone GFE into the `extern/` directory:
+1. Clone GFE (which vendors pFUnit) into `extern/gfe`, then build and install
+   it so CMake's `find_package(PFUNIT)` can find it:
    ```bash
-   cd extern
-   git clone https://github.com/Goddard-Fortran-Ecosystem/GFE.git
-   cd GFE
-   git submodule update --init
+   git clone https://github.com/Goddard-Fortran-Ecosystem/GFE extern/gfe
+   cd extern/gfe && git submodule update --init && cd ../..
+   cmake -S extern/gfe -B build-dev/extern/gfe -G "Unix Makefiles" \
+       -DCMAKE_CXX_COMPILER=g++ -DCMAKE_Fortran_COMPILER=gfortran \
+       -DCMAKE_INSTALL_PREFIX=build-dev/install -DCMAKE_BUILD_TYPE=Release \
+       -DSKIP_MPI=YES -DSKIP_OPENMP=YES -DSKIP_FHAMCREST=YES -DSKIP_ESMF=YES -DSKIP_ROBUST=YES
+   cmake --build build-dev/extern/gfe --target install
    ```
+   `scripts/develop.sh` automates these steps.
 
-2. Configure CEA with testing enabled (the `dev*` presets enable this by default):
+2. Configure CEA against that install and build (the `dev*` presets enable
+   `CEA_BUILD_TESTING` by default):
    ```bash
-   cmake --preset dev
+   cmake --preset dev -DCMAKE_PREFIX_PATH=build-dev/install
    cmake --build build-dev
    ```
+   If you already have PFUnit installed separately instead of building the
+   vendored copy above, set `PFUNIT_DIR` to its install prefix instead of
+   `CMAKE_PREFIX_PATH`.
 
 **Running all tests:**
 ```bash

--- a/README.md
+++ b/README.md
@@ -62,6 +62,15 @@ installation process is as follows:
     cmake --build .
     cmake --install .
 
+**Windows:** the command above needs an explicit `-G` generator flag — with
+none given and no Visual Studio installed, CMake defaults to NMake Makefiles
+and fails before reaching the Fortran compiler:
+
+    cmake -G "Visual Studio 17 2022" -DCMAKE_INSTALL_PREFIX=<cea_install_dir> -DCEA_BUILD_TESTING=OFF ..
+
+See the [Windows Notes](https://nasa.github.io/cea/installation.html#windows-notes)
+section of the full installation guide for Intel oneAPI and other options.
+
 This will build and install the `cea` executable, `libcea` library, default
 thermodynamic and transport property databases, documentation, and sample
 problems to the user-specified `cea_install_dir`.

--- a/docs/source/developer_guide.rst
+++ b/docs/source/developer_guide.rst
@@ -55,7 +55,9 @@ Prerequisites
 * Optional but strongly recommended: `Doxygen <https://www.doxygen.nl/>`_ to
   regenerate the XML that feeds the Sphinx API docs, and `PFUnit
   <https://github.com/Goddard-Fortran-Ecosystem/pFUnit>`_ support libraries for
-  unit testing (vendored in ``extern/GFE``).
+  unit testing, available via the vendored `GFE
+  <https://github.com/Goddard-Fortran-Ecosystem/GFE>`_ dependency (built into
+  ``extern/gfe``; see :ref:`testing` below).
 
 We provide a ``environment.yml`` file for quickly provisioning a ``conda`` /
 ``mamba`` environment with the complete toolchain::
@@ -128,6 +130,8 @@ Because the binding links against the ``libcea`` artifacts produced by CMake,
 rebuild the project whenever you touch Fortran sources before rerunning Python
 tests.
 
+.. _testing:
+
 Testing
 -------
 
@@ -141,9 +145,12 @@ whenever you modify solver behavior.
 
   (execute from the corresponding build directory).
 
-  PFUnit is a maintainer-only dependency; to run these tests locally, install
-  PFUnit (https://github.com/Goddard-Fortran-Ecosystem/pFUnit) and set ``PFUNIT_DIR``
-  to its install prefix.
+  Building this suite requires PFUnit, which is available via the vendored
+  GFE dependency. See `CONTRIBUTING.md <../../CONTRIBUTING.md>`_'s "Running
+  Tests" section for the full clone/build/install procedure
+  (``scripts/develop.sh`` automates it).
+  If you already have PFUnit installed separately, set ``PFUNIT_DIR`` to its
+  install prefix instead of building the vendored copy.
 
 * **CLI regression test** – ``ctest`` also registers ``cea_main_test`` which
   runs every RP‑1311 example input in ``samples/`` and checks the exit status of

--- a/docs/source/quick_start.rst
+++ b/docs/source/quick_start.rst
@@ -2,7 +2,8 @@ Quick Start
 ***********
 
 This guide walks through the bare essentials: installing CEA, running the
-command-line solver on the supplied sample problems, and calling the Python API.
+command-line solver on the supplied sample problems, and calling the Python
+and MATLAB APIs.
 
 Prerequisites
 -------------
@@ -11,6 +12,10 @@ Prerequisites
   Intel ``ifort`` 2021+).
 * `CMake <https://cmake.org>`_ ≥ 3.19 and a build tool (Ninja or Make).
 * Python ≥ 3.11 if you plan to use the Python binding.
+* MATLAB, if you plan to use the MATLAB binding — no prior Python
+  experience needed. The Quick MATLAB Example below walks through
+  everything, including installing Python itself if you don't already have
+  a copy.
 
 Installation
 ------------
@@ -108,6 +113,107 @@ factors in :mod:`cea.units` when working across unit systems.
 The ``EqSolver`` and its siblings ``RocketSolver``, ``ShockSolver``, and
 ``DetonationSolver`` expose the same properties as the Fortran core.  See
 :doc:`interfaces/python_api` for the full API reference.
+
+Quick MATLAB Example
+--------------------
+
+CEA doesn't ship a native MATLAB toolbox. Instead, MATLAB calls CEA through
+a small bridge to Python, using MATLAB's built-in ``pyenv`` feature. You
+don't need to know any Python to use it — follow the steps below once, then
+the two commands under "Every MATLAB Session" are all you'll retype.
+
+If you already have a working Python installation with ``cea`` installed,
+skip to "Every MATLAB Session" below.
+
+One-Time Setup
+~~~~~~~~~~~~~~
+
+1. Install Python, if you don't already have it. Download the Windows
+   installer for Python 3.12 from
+   `python.org <https://www.python.org/downloads/>`_ and run it. On the
+   first installer screen, check **"Add python.exe to PATH"** before
+   clicking "Install Now" — this lets you type ``python`` in a Command
+   Prompt window. (Python 3.12 is used here because it works with every
+   current MATLAB release; if MATLAB later refuses to load it, see the
+   troubleshooting note at the end of this step.)
+
+2. Open a Command Prompt window — a plain text window for typing commands,
+   separate from MATLAB. Click the Start menu (or press the Windows key),
+   type ``cmd``, and press Enter, or click "Command Prompt" in the search
+   results. If you had a Command Prompt window open before you installed
+   Python, close it and open a new one — it won't see the update otherwise.
+   Then install ``cea``::
+
+       python -m pip install cea
+
+   This downloads a ready-to-use package — no compiler, no conda, nothing
+   else to build.
+
+   *Troubleshooting:* if MATLAB later reports that this Python version
+   isn't supported, your MATLAB release may need an older or newer Python
+   than 3.12. Check MathWorks' `Python compatibility table
+   <https://www.mathworks.com/support/requirements/python-compatibility.html>`_
+   for your release, install that version from python.org instead (same
+   steps as above), and run ``python -m pip install cea`` again using that
+   version.
+
+3. In the same Command Prompt window, find the full path to the Python you
+   just installed — you'll paste it into MATLAB below::
+
+       where python
+
+   This prints one or more paths ending in ``python.exe``; copy the one
+   under the Python version you just installed (e.g.
+   ``C:\Users\<you>\AppData\Local\Programs\Python\Python312\python.exe``).
+
+Every MATLAB Session
+~~~~~~~~~~~~~~~~~~~~
+
+Paste these lines into the MATLAB Command Window, using the path from step 3
+above, before doing anything else with ``cea``::
+
+    pyenv('Version', 'C:\path\to\python.exe');
+
+    cea = py.importlib.import_module('cea');
+    ceam = py.importlib.import_module('cea.matlab');
+
+This only needs to run once per MATLAB session — running ``pyenv`` a second
+time after these lines have already run will error, so if you need to
+change the Python path, restart MATLAB first.
+
+*Tip:* save these three lines as a MATLAB script, e.g. ``setup_cea.m``, so
+each session you just type ``setup_cea`` instead of retyping them.
+
+Solving a Problem
+~~~~~~~~~~~~~~~~~
+
+With the session set up, solve a stoichiometric H\ :sub:`2`/O\ :sub:`2`
+constant-enthalpy, constant-pressure (HP) combustion problem — the
+adiabatic flame temperature of hydrogen burning in oxygen::
+
+    reactants = py.list({'H2', 'O2'});
+    pressure = cea.units.atm_to_bar(1.0);
+
+    solution = ceam.eq_solve(cea.HP, reactants, ...
+        fuel_amounts=py.numpy.array([2.0, 0.0]), ...
+        oxid_amounts=py.numpy.array([0.0, 1.0]), ...
+        moles=true, ...
+        T_reac=298.15, ...
+        P=pressure);
+
+    fprintf('Adiabatic flame temperature: %.1f K\n', solution.T);
+
+This should print ``Adiabatic flame temperature: 3074.5 K``.
+``fuel_amounts`` and ``oxid_amounts`` each list one amount per entry in
+``reactants``: ``[2.0, 0.0]`` is 2 mol of ``H2`` and 0 mol of ``O2`` on the
+fuel side, ``[0.0, 1.0]`` is 0 mol ``H2`` and 1 mol ``O2`` on the oxidizer
+side — together, 2 mol H2 to 1 mol O2.
+
+``solution`` holds the result as plain numbers and arrays you can read
+directly with dot notation, the same as any other MATLAB struct — no
+further conversion needed. ``solution.T`` above is the temperature in K;
+see :doc:`interfaces/matlab_api` for the full list of result fields and the
+other three solver functions (rocket, shock, and detonation problems).
 
 Reporting Issues
 ----------------

--- a/environment.yml
+++ b/environment.yml
@@ -5,9 +5,11 @@ channels:
 dependencies:
   - cmake
   - cython
-  - gcc
-  - gfortran
-  - gxx
+  - gcc=16.1
+  - gfortran=16.1
+  - gxx=16.1
+  - m2-m4
+  - make
   - ninja
   - numpy
   - pytest

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -108,16 +108,30 @@ if [ "$BUILD_GFE" = true ]; then
         git clone https://github.com/Goddard-Fortran-Ecosystem/GFE "${GFE}"
         (cd "${GFE}" && git submodule update --init)
     fi
-    cmake -S "${GFE}" -B "${GFE_BUILD}" -G "${GENERATOR}" \
-        -DCMAKE_CXX_COMPILER="${CXX}" \
-        -DCMAKE_Fortran_COMPILER="${FC}" \
-        -DCMAKE_INSTALL_PREFIX="${INSTALL}" \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DSKIP_MPI=YES \
-        -DSKIP_OPENMP=YES \
-        -DSKIP_FHAMCREST=YES \
-        -DSKIP_ESMF=YES \
+    GFE_CMAKE_ARGS=(
+        -DCMAKE_CXX_COMPILER="${CXX}"
+        -DCMAKE_Fortran_COMPILER="${FC}"
+        -DCMAKE_INSTALL_PREFIX="${INSTALL}"
+        -DCMAKE_BUILD_TYPE=Release
+        -DSKIP_MPI=YES
+        -DSKIP_OPENMP=YES
+        -DSKIP_FHAMCREST=YES
+        -DSKIP_ESMF=YES
         -DSKIP_ROBUST=YES
+    )
+    case "$(uname -s)" in
+        MINGW*|MSYS*|CYGWIN*)
+            # gfortran's -cpp preprocessor does not predefine _WIN32 the way a
+            # C/C++ compiler does, but pFUnit's FUnit.F90 guards its
+            # `use pf_RegexFilter` on `#ifndef _WIN32` while pFUnit's own
+            # CMakeLists excludes RegexFilter.F90 from the build via CMake's
+            # own (always-correct) WIN32 variable. Without this define,
+            # FUnit.F90 fails to compile: it tries to use a module that was
+            # never built.
+            GFE_CMAKE_ARGS+=(-DCMAKE_Fortran_FLAGS=-D_WIN32)
+            ;;
+    esac
+    cmake -S "${GFE}" -B "${GFE_BUILD}" -G "${GENERATOR}" "${GFE_CMAKE_ARGS[@]}"
     cmake --build ${GFE_BUILD} --target install -j ${JOBS}
 fi
 

--- a/source/bind/c/CMakeLists.txt
+++ b/source/bind/c/CMakeLists.txt
@@ -53,6 +53,14 @@ if (CEA_BUILD_TESTING)
         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
     )
 
+    add_executable(cea_bindc_solver_opts_validation tests/solver_opts_validation.c)
+    target_link_libraries(cea_bindc_solver_opts_validation PRIVATE cea::bindc)
+    add_test(
+        NAME cea_bindc_solver_opts_validation
+        COMMAND cea_bindc_solver_opts_validation
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    )
+
     add_executable(cea_bindc_rp1311_ex1 samples/rp1311_example1.c)
     target_link_libraries(cea_bindc_rp1311_ex1 PRIVATE cea::bindc)
     add_test(

--- a/source/bind/c/bindc.F90
+++ b/source/bind/c/bindc.F90
@@ -281,6 +281,70 @@ contains
         opts%truncation_width  = -1.0d0
     end function
 
+    subroutine parse_solver_opts(mptr_prod, opts, ierr, products, reactants, ions, transport, use_trace, insert)
+        ! Shared option decoding for cea_*_solver_create_with_options: reads the C
+        ! cea_solver_opts struct into the products/reactants mixtures, insert species
+        ! names, and boolean flags common to all solver types.
+        type(c_ptr), intent(in) :: mptr_prod
+        type(cea_solver_opts), intent(in) :: opts
+        integer(c_int), intent(out) :: ierr
+        type(Mixture), pointer, intent(out) :: products
+        type(Mixture), pointer, intent(out) :: reactants
+        logical, intent(out) :: ions, transport, use_trace
+        character(snl), allocatable, intent(out) :: insert(:)
+
+        ! Locals
+        type(c_ptr), pointer :: cinsert(:)
+        character(:), allocatable :: name
+        integer :: n
+
+        ierr = CEA_SUCCESS
+        call c_f_pointer(mptr_prod, products)
+
+        if (opts%ninsert < 0) then
+            ierr = CEA_INVALID_SIZE
+            return
+        end if
+        if (opts%ninsert > 0 .and. .not. c_associated(opts%insert)) then
+            ierr = CEA_INVALID_SIZE
+            return
+        end if
+
+        allocate(cinsert(opts%ninsert), insert(opts%ninsert))
+
+        ! Handle optional reactants mixture
+        if (c_associated(opts%reactants)) then
+            call c_f_pointer(opts%reactants, reactants)
+        else
+            nullify(reactants)
+        end if
+
+        ! Handle trace option
+        if (opts%trace > 0.0d0) then
+            use_trace = .true.
+        else
+            use_trace = .false.
+        end if
+
+        ! Convert ions from C bool to Fortran logical
+        ions = logical(opts%ions)
+        transport = logical(opts%transport)
+
+        ! Convert insert species names from C strings to Fortran strings
+        if (opts%ninsert > 0 .and. c_associated(opts%insert)) then
+            call c_f_pointer(opts%insert, cinsert, [opts%ninsert])
+
+            do n = 1, opts%ninsert
+                call c_copy(cinsert(n), name)
+                if (len(name) > snl) then
+                    ierr = CEA_INVALID_SIZE
+                    return
+                end if
+                insert(n) = name
+            end do
+        end if
+    end subroutine
+
     function cea_species_name_len(name_len) result(ierr) bind(c)
         integer(c_int) :: ierr
         integer(c_int), intent(out) :: name_len
@@ -1258,57 +1322,11 @@ contains
         type(EqSolver), pointer :: solver
         type(Mixture), pointer :: products
         type(Mixture), pointer :: reactants
-        type(c_ptr), pointer :: cinsert(:)
         character(snl), allocatable :: insert(:)
-        character(:), allocatable :: name
-        integer :: n
         logical :: ions, transport, use_trace
 
-        ierr = CEA_SUCCESS
-        call c_f_pointer(mptr_prod, products)
-
-        if (opts%ninsert < 0) then
-            ierr = CEA_INVALID_SIZE
-            return
-        end if
-        if (opts%ninsert > 0 .and. .not. c_associated(opts%insert)) then
-            ierr = CEA_INVALID_SIZE
-            return
-        end if
-
-        allocate(cinsert(opts%ninsert), insert(opts%ninsert))
-
-        ! Handle optional reactants mixture
-        if (c_associated(opts%reactants)) then
-            call c_f_pointer(opts%reactants, reactants)
-        else
-            nullify(reactants)
-        end if
-
-        ! Handle trace option
-        if (opts%trace > 0.0d0) then
-            use_trace = .true.
-        else
-            use_trace = .false.
-        end if
-
-        ! Convert ions from C bool to Fortran logical
-        ions = logical(opts%ions)
-        transport = logical(opts%transport)
-
-        ! Convert insert species names from C strings to Fortran strings
-        if (opts%ninsert > 0 .and. c_associated(opts%insert)) then
-            call c_f_pointer(opts%insert, cinsert, [opts%ninsert])
-
-            do n = 1, opts%ninsert
-                call c_copy(cinsert(n), name)
-                if (len(name) > snl) then
-                    ierr = CEA_INVALID_SIZE
-                    return
-                end if
-                insert(n) = name
-            end do
-        end if
+        call parse_solver_opts(mptr_prod, opts, ierr, products, reactants, ions, transport, use_trace, insert)
+        if (ierr /= CEA_SUCCESS) return
 
         allocate(solver)
         if (associated(reactants)) then
@@ -1546,57 +1564,11 @@ contains
         type(RocketSolver), pointer :: solver
         type(Mixture), pointer :: products
         type(Mixture), pointer :: reactants
-        type(c_ptr), pointer :: cinsert(:)
         character(snl), allocatable :: insert(:)
-        character(:), allocatable :: name
-        integer :: n
         logical :: ions, transport, use_trace
 
-        ierr = CEA_SUCCESS
-        call c_f_pointer(mptr_prod, products)
-
-        if (opts%ninsert < 0) then
-            ierr = CEA_INVALID_SIZE
-            return
-        end if
-        if (opts%ninsert > 0 .and. .not. c_associated(opts%insert)) then
-            ierr = CEA_INVALID_SIZE
-            return
-        end if
-
-        allocate(cinsert(opts%ninsert), insert(opts%ninsert))
-
-        ! Handle optional reactants mixture
-        if (c_associated(opts%reactants)) then
-            call c_f_pointer(opts%reactants, reactants)
-        else
-            nullify(reactants)
-        end if
-
-        ! Handle trace option
-        if (opts%trace > 0.0d0) then
-            use_trace = .true.
-        else
-            use_trace = .false.
-        end if
-
-        ! Convert ions from C bool to Fortran logical
-        ions = logical(opts%ions)
-        transport = logical(opts%transport)
-
-        ! Convert insert species names from C strings to Fortran strings
-        if (opts%ninsert > 0 .and. c_associated(opts%insert)) then
-            call c_f_pointer(opts%insert, cinsert, [opts%ninsert])
-
-            do n = 1, opts%ninsert
-                call c_copy(cinsert(n), name)
-                if (len(name) > snl) then
-                    ierr = CEA_INVALID_SIZE
-                    return
-                end if
-                insert(n) = name
-            end do
-        end if
+        call parse_solver_opts(mptr_prod, opts, ierr, products, reactants, ions, transport, use_trace, insert)
+        if (ierr /= CEA_SUCCESS) return
 
         allocate(solver)
         if (associated(reactants)) then
@@ -2376,57 +2348,11 @@ contains
         type(ShockSolver), pointer :: solver
         type(Mixture), pointer :: products
         type(Mixture), pointer :: reactants
-        type(c_ptr), pointer :: cinsert(:)
         character(snl), allocatable :: insert(:)
-        character(:), allocatable :: name
-        integer :: n
         logical :: ions, transport, use_trace
 
-        ierr = CEA_SUCCESS
-        call c_f_pointer(mptr_prod, products)
-
-        if (opts%ninsert < 0) then
-            ierr = CEA_INVALID_SIZE
-            return
-        end if
-        if (opts%ninsert > 0 .and. .not. c_associated(opts%insert)) then
-            ierr = CEA_INVALID_SIZE
-            return
-        end if
-
-        allocate(cinsert(opts%ninsert), insert(opts%ninsert))
-
-        ! Handle optional reactants mixture
-        if (c_associated(opts%reactants)) then
-            call c_f_pointer(opts%reactants, reactants)
-        else
-            nullify(reactants)
-        end if
-
-        ! Handle trace option
-        if (opts%trace > 0.0d0) then
-            use_trace = .true.
-        else
-            use_trace = .false.
-        end if
-
-        ! Convert ions from C bool to Fortran logical
-        ions = logical(opts%ions)
-        transport = logical(opts%transport)
-
-        ! Convert insert species names from C strings to Fortran strings
-        if (opts%ninsert > 0 .and. c_associated(opts%insert)) then
-            call c_f_pointer(opts%insert, cinsert, [opts%ninsert])
-
-            do n = 1, opts%ninsert
-                call c_copy(cinsert(n), name)
-                if (len(name) > snl) then
-                    ierr = CEA_INVALID_SIZE
-                    return
-                end if
-                insert(n) = name
-            end do
-        end if
+        call parse_solver_opts(mptr_prod, opts, ierr, products, reactants, ions, transport, use_trace, insert)
+        if (ierr /= CEA_SUCCESS) return
 
         allocate(solver)
         if (associated(reactants)) then
@@ -2650,57 +2576,11 @@ contains
         type(DetonSolver), pointer :: solver
         type(Mixture), pointer :: products
         type(Mixture), pointer :: reactants
-        type(c_ptr), pointer :: cinsert(:)
         character(snl), allocatable :: insert(:)
-        character(:), allocatable :: name
-        integer :: n
         logical :: ions, transport, use_trace
 
-        ierr = CEA_SUCCESS
-        call c_f_pointer(mptr_prod, products)
-
-        if (opts%ninsert < 0) then
-            ierr = CEA_INVALID_SIZE
-            return
-        end if
-        if (opts%ninsert > 0 .and. .not. c_associated(opts%insert)) then
-            ierr = CEA_INVALID_SIZE
-            return
-        end if
-
-        allocate(cinsert(opts%ninsert), insert(opts%ninsert))
-
-        ! Handle optional reactants mixture
-        if (c_associated(opts%reactants)) then
-            call c_f_pointer(opts%reactants, reactants)
-        else
-            nullify(reactants)
-        end if
-
-        ! Handle trace option
-        if (opts%trace > 0.0d0) then
-            use_trace = .true.
-        else
-            use_trace = .false.
-        end if
-
-        ! Convert ions from C bool to Fortran logical
-        ions = logical(opts%ions)
-        transport = logical(opts%transport)
-
-        ! Convert insert species names from C strings to Fortran strings
-        if (opts%ninsert > 0 .and. c_associated(opts%insert)) then
-            call c_f_pointer(opts%insert, cinsert, [opts%ninsert])
-
-            do n = 1, opts%ninsert
-                call c_copy(cinsert(n), name)
-                if (len(name) > snl) then
-                    ierr = CEA_INVALID_SIZE
-                    return
-                end if
-                insert(n) = name
-            end do
-        end if
+        call parse_solver_opts(mptr_prod, opts, ierr, products, reactants, ions, transport, use_trace, insert)
+        if (ierr /= CEA_SUCCESS) return
 
         allocate(solver)
         if (associated(reactants)) then

--- a/source/bind/c/tests/solver_opts_validation.c
+++ b/source/bind/c/tests/solver_opts_validation.c
@@ -1,0 +1,50 @@
+#include "cea.h"
+
+#include <stddef.h>
+
+int main(void)
+{
+    const cea_string reactants_names[] = {"N2 ", "CH4"};
+    const cea_string omitted[] = {""};
+    cea_mixture reac = NULL;
+    cea_mixture prod = NULL;
+    cea_eqsolver solver = NULL;
+    cea_solver_opts opts;
+
+    if (cea_init() != CEA_SUCCESS) return 1;
+    if (cea_mixture_create_w_ions(&reac, 2, reactants_names) != CEA_SUCCESS) return 2;
+    if (cea_mixture_create_from_reactants_w_ions(&prod, 2, reactants_names, 0, omitted) != CEA_SUCCESS) return 3;
+
+    // No reactants supplied: opts.reactants must be nullified rather than dereferenced.
+    cea_solver_opts_init(&opts);
+    if (cea_eqsolver_create_with_options(&solver, prod, opts) != CEA_SUCCESS) return 4;
+    cea_eqsolver_destroy(&solver);
+
+    // Negative ninsert is rejected.
+    cea_solver_opts_init(&opts);
+    opts.reactants = reac;
+    opts.ninsert = -1;
+    if (cea_eqsolver_create_with_options(&solver, prod, opts) != CEA_INVALID_SIZE) return 5;
+
+    // ninsert > 0 requires a non-null insert array.
+    cea_solver_opts_init(&opts);
+    opts.reactants = reac;
+    opts.ninsert = 2;
+    opts.insert = NULL;
+    if (cea_eqsolver_create_with_options(&solver, prod, opts) != CEA_INVALID_SIZE) return 6;
+
+    // Insert species names longer than species_name_len are rejected.
+    {
+        const cea_string insert[] = {"THIS_NAME_IS_WAY_TOO_LONG_FOR_A_SPECIES"};
+        cea_solver_opts_init(&opts);
+        opts.reactants = reac;
+        opts.ninsert = 1;
+        opts.insert = insert;
+        if (cea_eqsolver_create_with_options(&solver, prod, opts) != CEA_INVALID_SIZE) return 7;
+    }
+
+    cea_mixture_destroy(&prod);
+    cea_mixture_destroy(&reac);
+
+    return 0;
+}

--- a/source/bind/matlab/README.md
+++ b/source/bind/matlab/README.md
@@ -20,13 +20,9 @@ Recommended approach:
   ``ShockSolution`` / ``DetonationSolution`` object.
 - The wrapper module is pure Python. The ``CEA_ENABLE_BIND_MATLAB`` CMake
   option is a compatibility knob for MATLAB-via-Python workflows; it does not
-  build a separate supported ``ceam`` extension.
+  build a separate native MATLAB extension.
 - Example scripts live in ``source/bind/matlab/samples/``:
   ``equilibrium_example.m``, ``rocket_example.m``, ``shock_example.m``,
   ``detonation_example.m``.
-
-Legacy note:
-- ``source/bind/matlab/ceam.pyx`` is an old experimental artifact and is not the
-  supported interface path.
 
 If you need a native MATLAB interface, please open an issue or contribute fixes.

--- a/source/bind/python/CEA.pyx
+++ b/source/bind/python/CEA.pyx
@@ -4908,6 +4908,10 @@ cdef class DetonationSolution:
 # Matlab interface
 # ----------------
 
+# Universal gas constant in J/(kmol*K); must match cea_param.gas_constant
+# (source/param.f90.in) and cea.constants.R.
+GAS_CONSTANT = 8314.51
+
 def eq_solve(cea_equilibrium_type eq_type,
              list reactants,
              T: Optional[double] = None, H: Optional[double] = None, S: Optional[double] = None, U: Optional[double] = None,
@@ -4932,11 +4936,15 @@ def eq_solve(cea_equilibrium_type eq_type,
     T : float, optional
         Temperature value in K (mutually exclusive with H, S, U)
     H : float, optional
-        Enthalpy value in J/kg (mutually exclusive with T, S, U)
+        Enthalpy value in J/kg (mutually exclusive with T, S, U). Internally
+        divided by the gas constant R to match the solver's expected H/R
+        convention, same as the T_reac-derived value for HP problems.
     S : float, optional
-        Entropy value in J/(kg·K) (mutually exclusive with T, H, U)
+        Entropy value in J/(kg·K) (mutually exclusive with T, H, U). Internally
+        divided by R, same as the T_reac-derived value for SP/SV problems.
     U : float, optional
-        Internal energy value in J/kg (mutually exclusive with T, H, S)
+        Internal energy value in J/kg (mutually exclusive with T, H, S). Internally
+        divided by R, same as the T_reac-derived value for UV problems.
     P : float, optional
         Pressure value in bar (mutually exclusive with V)
     V : float, optional
@@ -5003,11 +5011,11 @@ def eq_solve(cea_equilibrium_type eq_type,
     if (T is not None):
         state1 = T
     elif (H is not None):
-        state1 = H
+        state1 = H / GAS_CONSTANT
     elif (S is not None):
-        state1 = S
+        state1 = S / GAS_CONSTANT
     elif (U is not None):
-        state1 = U
+        state1 = U / GAS_CONSTANT
 
     if (P is not None):
         state2 = P
@@ -5061,11 +5069,11 @@ def eq_solve(cea_equilibrium_type eq_type,
                 state1 = T_reac[0] if type(T_reac) in [list, np.ndarray] else T_reac
                 warnings.warn("Problem temperature not defined; using first reactant temperature")
             elif eq_type == HP:
-                state1 = reactants_mix.calc_property(ENTHALPY, weights, T_reac)
+                state1 = reactants_mix.calc_property(ENTHALPY, weights, T_reac) / GAS_CONSTANT
             elif eq_type == SP or eq_type == SV:
-                state1 = reactants_mix.calc_property(ENTROPY, weights, T_reac)
+                state1 = reactants_mix.calc_property(ENTROPY, weights, T_reac) / GAS_CONSTANT
             elif eq_type == UV:
-                state1 = reactants_mix.calc_property(ENERGY, weights, T_reac)
+                state1 = reactants_mix.calc_property(ENERGY, weights, T_reac) / GAS_CONSTANT
         else:
             raise TypeError("Reactant temperature not defined")
 

--- a/source/bind/python/cea/matlab.py
+++ b/source/bind/python/cea/matlab.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from typing import Optional, Sequence, SupportsFloat
+from typing import Callable, Optional, Sequence, SupportsFloat
 
 import numpy as np
 import numpy.typing as npt
@@ -25,6 +25,10 @@ VectorLike = Sequence[SupportsFloat] | FloatArray
 ScalarOrArray = SupportsFloat | VectorLike
 
 __all__ = ["eq_solve", "rocket_solve", "shock_solve", "detonation_solve"]
+
+
+def _copy_array(value: object) -> FloatArray:
+    return np.array(value, copy=True)
 
 
 def _copy_scalar_or_array(value: object) -> float | bool | int | FloatArray:
@@ -226,35 +230,47 @@ def _build_detonation_solver(
     return DetonationSolver(products_mix, **kwargs)
 
 
+_FieldSpec = str | tuple[str, Callable[[object], object]]
+
+
+def _flatten_fields(
+    soln: object,
+    fields: Sequence[_FieldSpec],
+    wrapper: Callable[[object], object],
+    *,
+    overrides: Optional[dict[str, object]] = None,
+) -> dict[str, object]:
+    values: dict[str, object] = {}
+    for field in fields:
+        name, field_wrapper = field if isinstance(field, tuple) else (field, wrapper)
+        if overrides is not None and name in overrides:
+            values[name] = overrides[name]
+        else:
+            values[name] = field_wrapper(getattr(soln, name))
+    return values
+
+
+_EQ_FIELDS: tuple[_FieldSpec, ...] = (
+    "T", "P", "volume", "density", "M", "MW", "enthalpy", "energy", "entropy",
+    "gibbs_energy", "gamma_s", "cp_fr", "cp_eq", "cp", "cv_fr", "cv_eq", "cv",
+    "viscosity", "conductivity_fr", "conductivity_eq", "Pr_fr", "Pr_eq",
+    ("nj", _copy_array), ("ln_nj", _copy_array), "n",
+)
+
+_ROCKET_FIELDS: tuple[_FieldSpec, ...] = (
+    "T", "P", "volume", "density", "M", "MW", "enthalpy", "energy", "entropy",
+    "gibbs_energy", "gamma_s", "cp_fr", "cp_eq", "cp", "cv_fr", "cv_eq", "cv",
+    "Mach", "sonic_velocity", "ae_at", "c_star", "coefficient_of_thrust",
+    "Isp", "Isp_vacuum", "viscosity", "conductivity_fr", "conductivity_eq",
+    "Pr_fr", "Pr_eq", "nj", "ln_nj", "n",
+)
+
+
 def _flatten_eq_solution(soln: EqSolution) -> SimpleNamespace:
     return SimpleNamespace(
         last_error=int(soln.last_error),
         converged=bool(soln.converged),
-        T=float(soln.T),
-        P=float(soln.P),
-        volume=float(soln.volume),
-        density=float(soln.density),
-        M=float(soln.M),
-        MW=float(soln.MW),
-        enthalpy=float(soln.enthalpy),
-        energy=float(soln.energy),
-        entropy=float(soln.entropy),
-        gibbs_energy=float(soln.gibbs_energy),
-        gamma_s=float(soln.gamma_s),
-        cp_fr=float(soln.cp_fr),
-        cp_eq=float(soln.cp_eq),
-        cp=float(soln.cp),
-        cv_fr=float(soln.cv_fr),
-        cv_eq=float(soln.cv_eq),
-        cv=float(soln.cv),
-        viscosity=float(soln.viscosity),
-        conductivity_fr=float(soln.conductivity_fr),
-        conductivity_eq=float(soln.conductivity_eq),
-        Pr_fr=float(soln.Pr_fr),
-        Pr_eq=float(soln.Pr_eq),
-        nj=np.array(soln.nj, copy=True),
-        ln_nj=np.array(soln.ln_nj, copy=True),
-        n=float(soln.n),
+        **_flatten_fields(soln, _EQ_FIELDS, float),
         mass_fractions=dict(soln.mass_fractions),
         mole_fractions=dict(soln.mole_fractions),
     )
@@ -265,38 +281,7 @@ def _flatten_rocket_solution(soln: RocketSolution) -> SimpleNamespace:
         last_error=int(soln.last_error),
         converged=bool(soln.converged),
         num_pts=int(soln.num_pts),
-        T=np.array(soln.T, copy=True),
-        P=np.array(soln.P, copy=True),
-        volume=np.array(soln.volume, copy=True),
-        density=np.array(soln.density, copy=True),
-        M=np.array(soln.M, copy=True),
-        MW=np.array(soln.MW, copy=True),
-        enthalpy=np.array(soln.enthalpy, copy=True),
-        energy=np.array(soln.energy, copy=True),
-        entropy=np.array(soln.entropy, copy=True),
-        gibbs_energy=np.array(soln.gibbs_energy, copy=True),
-        gamma_s=np.array(soln.gamma_s, copy=True),
-        cp_fr=np.array(soln.cp_fr, copy=True),
-        cp_eq=np.array(soln.cp_eq, copy=True),
-        cp=np.array(soln.cp, copy=True),
-        cv_fr=np.array(soln.cv_fr, copy=True),
-        cv_eq=np.array(soln.cv_eq, copy=True),
-        cv=np.array(soln.cv, copy=True),
-        Mach=np.array(soln.Mach, copy=True),
-        sonic_velocity=np.array(soln.sonic_velocity, copy=True),
-        ae_at=np.array(soln.ae_at, copy=True),
-        c_star=np.array(soln.c_star, copy=True),
-        coefficient_of_thrust=np.array(soln.coefficient_of_thrust, copy=True),
-        Isp=np.array(soln.Isp, copy=True),
-        Isp_vacuum=np.array(soln.Isp_vacuum, copy=True),
-        viscosity=np.array(soln.viscosity, copy=True),
-        conductivity_fr=np.array(soln.conductivity_fr, copy=True),
-        conductivity_eq=np.array(soln.conductivity_eq, copy=True),
-        Pr_fr=np.array(soln.Pr_fr, copy=True),
-        Pr_eq=np.array(soln.Pr_eq, copy=True),
-        nj=np.array(soln.nj, copy=True),
-        ln_nj=np.array(soln.ln_nj, copy=True),
-        n=np.array(soln.n, copy=True),
+        **_flatten_fields(soln, _ROCKET_FIELDS, _copy_array),
         mass_fractions=_copy_fraction_dict(soln.mass_fractions),
         mole_fractions=_copy_fraction_dict(soln.mole_fractions),
     )
@@ -317,49 +302,35 @@ def _reconstruct_shock_amounts(soln: ShockSolution) -> tuple[FloatArray, FloatAr
     return total_moles, nj, ln_nj
 
 
+_SHOCK_FIELDS: tuple[_FieldSpec, ...] = (
+    "T", "P", "velocity", "Mach", "sonic_velocity", "rho12", "rho52", "P21",
+    "P52", "T21", "T52", "M21", "M52", "v2", "u5_p_v2", "volume", "density",
+    "M", "MW", "enthalpy", "energy", "entropy", "gibbs_energy", "gamma_s",
+    "cp_fr", "cp_eq", "cp", "cv_fr", "cv_eq", "cv", "viscosity",
+    "conductivity_fr", "conductivity_eq", "Pr_fr", "Pr_eq", "nj", "ln_nj", "n",
+)
+
+_DETONATION_FIELDS: tuple[_FieldSpec, ...] = (
+    "P1", "T1", "H1", "M1", "gamma1", "sonic_velocity1", "P", "T", "density",
+    "enthalpy", "energy", "gibbs_energy", "entropy", "Mach", "velocity",
+    "sonic_velocity", "gamma_s", "P_P1", "T_T1", "M_M1", "rho_rho1", "cp_fr",
+    "cv_fr", "cp_eq", "cv_eq", "M", "MW", "viscosity", "conductivity_fr",
+    "conductivity_eq", "Pr_fr", "Pr_eq",
+    ("nj", _copy_array), ("ln_nj", _copy_array), "n",
+)
+
+
 def _flatten_shock_solution(soln: ShockSolution) -> SimpleNamespace:
     total_moles, species_amounts, log_species_amounts = _reconstruct_shock_amounts(soln)
     return SimpleNamespace(
         last_error=int(soln.last_error),
         converged=bool(soln.converged),
-        T=_copy_scalar_or_array(soln.T),
-        P=_copy_scalar_or_array(soln.P),
-        velocity=_copy_scalar_or_array(soln.velocity),
-        Mach=_copy_scalar_or_array(soln.Mach),
-        sonic_velocity=_copy_scalar_or_array(soln.sonic_velocity),
-        rho12=_copy_scalar_or_array(soln.rho12),
-        rho52=_copy_scalar_or_array(soln.rho52),
-        P21=_copy_scalar_or_array(soln.P21),
-        P52=_copy_scalar_or_array(soln.P52),
-        T21=_copy_scalar_or_array(soln.T21),
-        T52=_copy_scalar_or_array(soln.T52),
-        M21=_copy_scalar_or_array(soln.M21),
-        M52=_copy_scalar_or_array(soln.M52),
-        v2=_copy_scalar_or_array(soln.v2),
-        u5_p_v2=_copy_scalar_or_array(soln.u5_p_v2),
-        volume=_copy_scalar_or_array(soln.volume),
-        density=_copy_scalar_or_array(soln.density),
-        M=_copy_scalar_or_array(soln.M),
-        MW=_copy_scalar_or_array(soln.MW),
-        enthalpy=_copy_scalar_or_array(soln.enthalpy),
-        energy=_copy_scalar_or_array(soln.energy),
-        entropy=_copy_scalar_or_array(soln.entropy),
-        gibbs_energy=_copy_scalar_or_array(soln.gibbs_energy),
-        gamma_s=_copy_scalar_or_array(soln.gamma_s),
-        cp_fr=_copy_scalar_or_array(soln.cp_fr),
-        cp_eq=_copy_scalar_or_array(soln.cp_eq),
-        cp=_copy_scalar_or_array(soln.cp),
-        cv_fr=_copy_scalar_or_array(soln.cv_fr),
-        cv_eq=_copy_scalar_or_array(soln.cv_eq),
-        cv=_copy_scalar_or_array(soln.cv),
-        viscosity=_copy_scalar_or_array(soln.viscosity),
-        conductivity_fr=_copy_scalar_or_array(soln.conductivity_fr),
-        conductivity_eq=_copy_scalar_or_array(soln.conductivity_eq),
-        Pr_fr=_copy_scalar_or_array(soln.Pr_fr),
-        Pr_eq=_copy_scalar_or_array(soln.Pr_eq),
-        nj=species_amounts,
-        ln_nj=log_species_amounts,
-        n=total_moles,
+        **_flatten_fields(
+            soln,
+            _SHOCK_FIELDS,
+            _copy_scalar_or_array,
+            overrides={"nj": species_amounts, "ln_nj": log_species_amounts, "n": total_moles},
+        ),
         mass_fractions=_copy_fraction_dict(soln.mass_fractions),
         mole_fractions=_copy_fraction_dict(soln.mole_fractions),
     )
@@ -369,41 +340,7 @@ def _flatten_detonation_solution(soln: DetonationSolution) -> SimpleNamespace:
     return SimpleNamespace(
         last_error=int(soln.last_error),
         converged=bool(soln.converged),
-        P1=float(soln.P1),
-        T1=float(soln.T1),
-        H1=float(soln.H1),
-        M1=float(soln.M1),
-        gamma1=float(soln.gamma1),
-        sonic_velocity1=float(soln.sonic_velocity1),
-        P=float(soln.P),
-        T=float(soln.T),
-        density=float(soln.density),
-        enthalpy=float(soln.enthalpy),
-        energy=float(soln.energy),
-        gibbs_energy=float(soln.gibbs_energy),
-        entropy=float(soln.entropy),
-        Mach=float(soln.Mach),
-        velocity=float(soln.velocity),
-        sonic_velocity=float(soln.sonic_velocity),
-        gamma_s=float(soln.gamma_s),
-        P_P1=float(soln.P_P1),
-        T_T1=float(soln.T_T1),
-        M_M1=float(soln.M_M1),
-        rho_rho1=float(soln.rho_rho1),
-        cp_fr=float(soln.cp_fr),
-        cv_fr=float(soln.cv_fr),
-        cp_eq=float(soln.cp_eq),
-        cv_eq=float(soln.cv_eq),
-        M=float(soln.M),
-        MW=float(soln.MW),
-        viscosity=float(soln.viscosity),
-        conductivity_fr=float(soln.conductivity_fr),
-        conductivity_eq=float(soln.conductivity_eq),
-        Pr_fr=float(soln.Pr_fr),
-        Pr_eq=float(soln.Pr_eq),
-        nj=np.array(soln.nj, copy=True),
-        ln_nj=np.array(soln.ln_nj, copy=True),
-        n=float(soln.n),
+        **_flatten_fields(soln, _DETONATION_FIELDS, float),
         mass_fractions=dict(soln.mass_fractions),
         mole_fractions=dict(soln.mole_fractions),
     )

--- a/source/bind/python/tests/test_abort_recovery.py
+++ b/source/bind/python/tests/test_abort_recovery.py
@@ -50,3 +50,45 @@ def test_rocket_abort_raises_runtimeerror_and_python_continues():
     assert result.returncode == 0, combined
     assert "CAUGHT_RUNTIME_ERROR" in result.stdout, combined
     assert "CONTINUED_AFTER_ERROR" in result.stdout, combined
+
+
+@pytest.mark.smoke
+def test_detonation_frozen_raises_runtimeerror_and_python_continues():
+    code = textwrap.dedent(
+        """
+        import numpy as np
+        import cea
+
+        reac_names = ["H2", "O2"]
+        reac = cea.Mixture(reac_names)
+        prod = cea.Mixture(reac_names, products_from_reactants=True)
+        solver = cea.DetonationSolver(prod, reactants=reac)
+        soln = cea.DetonationSolution(solver)
+
+        weights = np.array([0.0, 1.0], dtype=np.float64)
+
+        try:
+            solver.solve(soln, weights, 298.15, 1.0, frozen=True)
+        except RuntimeError as exc:
+            message = str(exc)
+            assert "CEA_FORTRAN_ABORT" in message
+            assert "frozen composition not supported yet" in message
+            print("CAUGHT_RUNTIME_ERROR")
+        else:
+            raise AssertionError("Expected DetonationSolver.solve to raise RuntimeError")
+
+        print("CONTINUED_AFTER_ERROR")
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=20,
+    )
+    combined = result.stdout + result.stderr
+
+    assert result.returncode == 0, combined
+    assert "CAUGHT_RUNTIME_ERROR" in result.stdout, combined
+    assert "CONTINUED_AFTER_ERROR" in result.stdout, combined

--- a/source/bind/python/tests/test_matlab_wrapper.py
+++ b/source/bind/python/tests/test_matlab_wrapper.py
@@ -1,6 +1,68 @@
 import numpy as np
 import pytest
 
+# Field names taken from the `property` blocks on each compiled solution
+# class in CEA.pyx (not from cea.matlab's own field lists), so these checks
+# don't just validate the wrapper's field lists against themselves.
+_EQ_ALL_FIELDS = (
+    "T", "P", "volume", "density", "M", "MW", "enthalpy", "energy", "entropy",
+    "gibbs_energy", "gamma_s", "cp_fr", "cp_eq", "cp", "cv_fr", "cv_eq", "cv",
+    "viscosity", "conductivity_fr", "conductivity_eq", "Pr_fr", "Pr_eq",
+    "nj", "ln_nj", "n",
+)
+
+_ROCKET_ALL_FIELDS = (
+    "T", "P", "volume", "density", "M", "MW", "enthalpy", "energy", "entropy",
+    "gibbs_energy", "gamma_s", "cp_fr", "cp_eq", "cp", "cv_fr", "cv_eq", "cv",
+    "Mach", "sonic_velocity", "ae_at", "c_star", "coefficient_of_thrust",
+    "Isp", "Isp_vacuum", "viscosity", "conductivity_fr", "conductivity_eq",
+    "Pr_fr", "Pr_eq", "nj", "ln_nj", "n",
+)
+
+# ShockSolution.nj/ln_nj/n are excluded: the compiled class's own properties
+# raise AttributeError (ShockSolution._get_weights calls a _get_size method
+# that only RocketSolution defines), so cea.matlab reconstructs them from
+# mole_fractions instead (see _reconstruct_shock_amounts) and there is no
+# working compiled-side value to compare against.
+_SHOCK_ALL_FIELDS = (
+    "T", "P", "velocity", "Mach", "sonic_velocity", "rho12", "rho52", "P21",
+    "P52", "T21", "T52", "M21", "M52", "v2", "u5_p_v2", "volume", "density",
+    "M", "MW", "enthalpy", "energy", "entropy", "gibbs_energy", "gamma_s",
+    "cp_fr", "cp_eq", "cp", "cv_fr", "cv_eq", "cv", "viscosity",
+    "conductivity_fr", "conductivity_eq", "Pr_fr", "Pr_eq",
+)
+
+_DETONATION_ALL_FIELDS = (
+    "P1", "T1", "H1", "M1", "gamma1", "sonic_velocity1", "P", "T", "density",
+    "enthalpy", "energy", "gibbs_energy", "entropy", "Mach", "velocity",
+    "sonic_velocity", "gamma_s", "P_P1", "T_T1", "M_M1", "rho_rho1", "cp_fr",
+    "cv_fr", "cp_eq", "cv_eq", "M", "MW", "viscosity", "conductivity_fr",
+    "conductivity_eq", "Pr_fr", "Pr_eq", "nj", "ln_nj", "n",
+)
+
+
+def _assert_fraction_dicts_match(wrapper_fractions, compiled_fractions):
+    assert wrapper_fractions.keys() == compiled_fractions.keys()
+    for name, compiled_value in compiled_fractions.items():
+        np.testing.assert_allclose(
+            wrapper_fractions[name],
+            compiled_value,
+            rtol=0.0,
+            atol=0.0,
+            err_msg=f"fraction {name!r} did not match the compiled solution",
+        )
+
+
+def _assert_all_fields_match(wrapper_soln, compiled_soln, field_names):
+    for name in field_names:
+        np.testing.assert_allclose(
+            getattr(wrapper_soln, name),
+            getattr(compiled_soln, name),
+            rtol=0.0,
+            atol=0.0,
+            err_msg=f"field {name!r} did not match the compiled solution",
+        )
+
 
 def _wrapper_case_inputs():
     reactants = ["H2", "O2"]
@@ -87,33 +149,7 @@ def test_matlab_eq_solve_matches_compiled_eq_solve(cea_module):
 
     assert wrapper_soln.converged == compiled_soln.converged
     assert wrapper_soln.last_error == compiled_soln.last_error
-    np.testing.assert_allclose(wrapper_soln.T, compiled_soln.T, rtol=0.0, atol=0.0)
-    np.testing.assert_allclose(wrapper_soln.P, compiled_soln.P, rtol=0.0, atol=0.0)
-    np.testing.assert_allclose(wrapper_soln.MW, compiled_soln.MW, rtol=0.0, atol=0.0)
-    np.testing.assert_allclose(
-        wrapper_soln.enthalpy,
-        compiled_soln.enthalpy,
-        rtol=0.0,
-        atol=0.0,
-    )
-    np.testing.assert_allclose(
-        wrapper_soln.cp_eq,
-        compiled_soln.cp_eq,
-        rtol=0.0,
-        atol=0.0,
-    )
-    np.testing.assert_allclose(
-        wrapper_soln.nj,
-        compiled_soln.nj,
-        rtol=0.0,
-        atol=0.0,
-    )
-    np.testing.assert_allclose(
-        wrapper_soln.ln_nj,
-        compiled_soln.ln_nj,
-        rtol=0.0,
-        atol=0.0,
-    )
+    _assert_all_fields_match(wrapper_soln, compiled_soln, _EQ_ALL_FIELDS)
     assert wrapper_soln.mass_fractions == compiled_soln.mass_fractions
     assert wrapper_soln.mole_fractions == compiled_soln.mole_fractions
 
@@ -186,20 +222,9 @@ def test_matlab_rocket_solve_matches_compiled_solver(cea_module):
     assert wrapper_soln.converged == compiled_soln.converged
     assert wrapper_soln.last_error == compiled_soln.last_error
     assert wrapper_soln.num_pts == compiled_soln.num_pts
-    np.testing.assert_allclose(wrapper_soln.T, compiled_soln.T, rtol=0.0, atol=0.0)
-    np.testing.assert_allclose(wrapper_soln.P, compiled_soln.P, rtol=0.0, atol=0.0)
-    np.testing.assert_allclose(
-        wrapper_soln.c_star,
-        compiled_soln.c_star,
-        rtol=0.0,
-        atol=0.0,
-    )
-    np.testing.assert_allclose(
-        wrapper_soln.Isp_vacuum,
-        compiled_soln.Isp_vacuum,
-        rtol=0.0,
-        atol=0.0,
-    )
+    _assert_all_fields_match(wrapper_soln, compiled_soln, _ROCKET_ALL_FIELDS)
+    _assert_fraction_dicts_match(wrapper_soln.mass_fractions, compiled_soln.mass_fractions)
+    _assert_fraction_dicts_match(wrapper_soln.mole_fractions, compiled_soln.mole_fractions)
 
 
 def test_matlab_shock_solve_matches_compiled_solver(cea_module):
@@ -235,16 +260,9 @@ def test_matlab_shock_solve_matches_compiled_solver(cea_module):
     assert not hasattr(wrapper_soln, "solver")
     assert wrapper_soln.converged == compiled_soln.converged
     assert wrapper_soln.last_error == compiled_soln.last_error
-    np.testing.assert_allclose(wrapper_soln.T, compiled_soln.T, rtol=0.0, atol=0.0)
-    np.testing.assert_allclose(wrapper_soln.P, compiled_soln.P, rtol=0.0, atol=0.0)
-    np.testing.assert_allclose(
-        wrapper_soln.velocity,
-        compiled_soln.velocity,
-        rtol=0.0,
-        atol=0.0,
-    )
-    np.testing.assert_allclose(wrapper_soln.P21, compiled_soln.P21, rtol=0.0, atol=0.0)
-    np.testing.assert_allclose(wrapper_soln.P52, compiled_soln.P52, rtol=0.0, atol=0.0)
+    _assert_all_fields_match(wrapper_soln, compiled_soln, _SHOCK_ALL_FIELDS)
+    _assert_fraction_dicts_match(wrapper_soln.mass_fractions, compiled_soln.mass_fractions)
+    _assert_fraction_dicts_match(wrapper_soln.mole_fractions, compiled_soln.mole_fractions)
 
 
 def test_matlab_detonation_solve_matches_compiled_solver(cea_module):
@@ -273,17 +291,6 @@ def test_matlab_detonation_solve_matches_compiled_solver(cea_module):
     assert not hasattr(wrapper_soln, "solver")
     assert wrapper_soln.converged == compiled_soln.converged
     assert wrapper_soln.last_error == compiled_soln.last_error
-    np.testing.assert_allclose(wrapper_soln.T, compiled_soln.T, rtol=0.0, atol=0.0)
-    np.testing.assert_allclose(wrapper_soln.P, compiled_soln.P, rtol=0.0, atol=0.0)
-    np.testing.assert_allclose(
-        wrapper_soln.velocity,
-        compiled_soln.velocity,
-        rtol=0.0,
-        atol=0.0,
-    )
-    np.testing.assert_allclose(
-        wrapper_soln.P_P1,
-        compiled_soln.P_P1,
-        rtol=0.0,
-        atol=0.0,
-    )
+    _assert_all_fields_match(wrapper_soln, compiled_soln, _DETONATION_ALL_FIELDS)
+    assert wrapper_soln.mass_fractions == compiled_soln.mass_fractions
+    assert wrapper_soln.mole_fractions == compiled_soln.mole_fractions

--- a/source/bind/python/tests/test_matlab_wrapper.py
+++ b/source/bind/python/tests/test_matlab_wrapper.py
@@ -154,6 +154,46 @@ def test_matlab_eq_solve_matches_compiled_eq_solve(cea_module):
     assert wrapper_soln.mole_fractions == compiled_soln.mole_fractions
 
 
+def test_eq_solve_hp_state1_divides_by_gas_constant(cea_module):
+    # eq_solve's HP/SP/UV `state1` must be in the H/R convention the Fortran
+    # core expects, both when T_reac drives the enthalpy calculation and when
+    # H is passed directly. Before the fix, both paths passed the raw
+    # (non-/R) enthalpy through and failed to converge.
+    import cea.matlab
+
+    reactants = ["H2", "O2"]
+    fuel_amounts = np.array([1.0, 0.0], dtype=np.float64)
+    oxid_amounts = np.array([0.0, 1.0], dtype=np.float64)
+
+    soln_t_reac = cea.matlab.eq_solve(
+        cea_module.HP,
+        reactants,
+        P=1.0,
+        T_reac=1000.0,
+        fuel_amounts=fuel_amounts,
+        oxid_amounts=oxid_amounts,
+        of_ratio=8.0,
+    )
+    assert soln_t_reac.converged
+    np.testing.assert_allclose(soln_t_reac.T, 3155.4878196910463, rtol=1e-9)
+
+    reactants_mix = cea_module.Mixture(reactants)
+    weights = reactants_mix.of_ratio_to_weights(oxid_amounts, fuel_amounts, 8.0)
+    h0 = reactants_mix.calc_property(cea_module.ENTHALPY, weights, 1000.0)
+
+    soln_h = cea.matlab.eq_solve(
+        cea_module.HP,
+        reactants,
+        P=1.0,
+        H=h0,
+        fuel_amounts=fuel_amounts,
+        oxid_amounts=oxid_amounts,
+        of_ratio=8.0,
+    )
+    assert soln_h.converged
+    np.testing.assert_allclose(soln_h.T, soln_t_reac.T, rtol=0.0, atol=0.0)
+
+
 def test_root_eq_solve_shim_warns_and_forwards(cea_module):
     reactants, fuel_amounts, oxid_amounts = _wrapper_case_inputs()
     with pytest.warns(

--- a/source/bind/python/tests/test_reuse_solution.py
+++ b/source/bind/python/tests/test_reuse_solution.py
@@ -71,3 +71,39 @@ def test_issue42_reused_eqsolution_matches_fresh():
     assert reuse_soln.T == pytest.approx(fresh_soln.T, rel=1.0e-6)
     assert reuse_soln.n == pytest.approx(fresh_soln.n, rel=1.0e-6)
     assert np.allclose(reuse_soln.nj, fresh_soln.nj, rtol=1.0e-6, atol=1.0e-12)
+
+
+def test_reused_eqsolution_cp_matches_fresh():
+    # Regression test for the EqSolver_post_process cp_fr/cp_eq dedup
+    # (djkees/cea#30): a reused EqSolution starts each solve with the
+    # cp_fr/cp_eq values left over from the previous solve, so the
+    # `< 1.d-10` guards that skip recomputation must still be evaluated
+    # independently per field rather than short-circuited together.
+    reac_names = ["O2", "C2H4"]
+    reac = cea.Mixture(reac_names)
+    prod = cea.Mixture(reac_names, products_from_reactants=True)
+
+    p1 = 60.0
+    h1 = 129.92208593485029
+    p2 = 95.242559745142628
+    t2 = 3585.9524742656135
+
+    wo = np.array((1.0, 0.0))
+    wf = np.array((0.0, 1.0))
+    of_ratio = reac.weight_eq_ratio_to_of_ratio(wo, wf, 0.4)
+    weights = reac.of_ratio_to_weights(wo, wf, of_ratio)
+
+    solver = cea.EqSolver(prod, reactants=reac)
+
+    reuse_soln = cea.EqSolution(solver)
+    solver.solve(reuse_soln, cea.HP, h1, p1, weights)
+    assert reuse_soln.converged
+    solver.solve(reuse_soln, cea.TP, t2, p2, weights)
+    assert reuse_soln.converged
+
+    fresh_soln = cea.EqSolution(solver)
+    solver.solve(fresh_soln, cea.TP, t2, p2, weights)
+    assert fresh_soln.converged
+
+    assert reuse_soln.cp_fr == pytest.approx(fresh_soln.cp_fr, rel=1.0e-6)
+    assert reuse_soln.cp_eq == pytest.approx(fresh_soln.cp_eq, rel=1.0e-6)

--- a/source/detonation.f90
+++ b/source/detonation.f90
@@ -298,8 +298,7 @@ contains
 
         ! Call the solver
         if (frozen_) then
-            call log_info('DetonSolver: frozen composition not supported yet')
-            ! call self%solve_frozen(soln, reactant_weights, t1, p1)
+            call abort('DetonSolver: frozen composition not supported yet')
         else
             call self%solve_eq(soln, reactant_weights, t1, p1)
         end if

--- a/source/equilibrium.f90
+++ b/source/equilibrium.f90
@@ -5168,7 +5168,10 @@ contains
         logical, allocatable :: selected_species(:)
 
         logical :: frozen_transport_only
-        real(dp), parameter :: transport_log_cutoff = 25.328436d0
+        real(dp) :: ln_n                      ! log of total gas moles, for the trace-species reactivation threshold
+        real(dp) :: ln_threshold              ! Species-amount activity threshold (tsize/esize-based)
+        real(dp) :: nj_eff_tmp                ! Smooth-truncation-aware effective species amount
+        logical :: ion_species                ! True if gas species is charged and ions are active
 
         frozen_transport_only = .false.
         if (present(frozen_shock)) frozen_transport_only = frozen_shock
@@ -5208,13 +5211,38 @@ contains
         if (eq_solver%ions) max_elem_idx = max_elem_idx - 1
         nj_el = 0.0d0
 
+        ! Revive gas species already zeroed for reporting if they remain active by the
+        ! same tsize/esize threshold (and smooth_truncation gate) used elsewhere in the solve,
+        ! so trace-species screening for the transport-species list stays consistent
+        ! with the rest of the smooth-truncation machinery.
+        !
+        ! NOTE: In the typical converged path, eq_soln%nj(i) was already zeroed by
+        ! compute_reported_nj using the far more permissive log_min (~-87) floor, while
+        ! tsize/esize offsets are only ~18-32 -- so in practice this loop rarely has any
+        ! species to revive; it mainly matters in the singular-matrix fallback path,
+        ! where nj is still gated directly by tsize. A future, tighter or user-configurable
+        ! reporting floor (replacing the fixed log_min) would make this loop load-bearing
+        ! far more often.
+        ln_n = log(eq_soln%n)
         do i = 1, ng
-            ! TODO(smooth_truncation): transport species screening currently uses hard-zero semantics.
-            ! Revisit whether smooth mode should use a practical-zero cutoff instead.
+            ! Only species already reported as zero are candidates for revival here;
+            ! species still positive keep whatever value they already have.
             if (eq_soln%nj(i) <= 0.0d0) then
-                if (eq_soln%ln_nj(i) - log(eq_soln%n) + transport_log_cutoff > 0.0d0) then
-                    eq_soln%nj(i) = exp(eq_soln%ln_nj(i))
-                end if
+                ! Ions get the looser esize threshold instead of tsize, matching every
+                ! other activity check in this file
+                ion_species = eq_solver%ions .and. eq_solver%active_ions .and. ne > 0 .and. A(i, ne) /= 0.0d0
+                ! Species-amount threshold below which species i is treated as inactive:
+                ! ln_threshold = ln_n - tsize (or - esize for ions).
+                ln_threshold = gas_amount_ln_threshold(ln_n, eq_solver%tsize, eq_solver%esize, ion_species)
+                ! Hard mode: nj_eff_tmp is exp(ln_nj) if above threshold, else exactly 0.
+                !
+                ! Smooth mode: nj_eff_tmp is exp(ln_nj) scaled by a logistic gate that ramps
+                ! from 0 to 1 across truncation_width, rather than snapping on at the threshold.
+                call compute_nj_effective(eq_soln%ln_nj(i), ln_threshold, eq_solver%smooth_truncation, &
+                                          eq_solver%truncation_width, nj_eff_tmp)
+                ! Only overwrite nj(i) when the gate actually revives it; never write an
+                ! explicit 0.0 here so an already-reported 0 is left untouched.
+                if (nj_eff_tmp > 0.0d0) eq_soln%nj(i) = nj_eff_tmp
             end if
         end do
 

--- a/source/equilibrium.f90
+++ b/source/equilibrium.f90
@@ -2305,6 +2305,8 @@ contains
         logical :: computed_partials_
         real(dp) :: entropy_sum
         real(dp) :: log_p_over_n
+        real(dp) :: cp_dot_nj
+        logical :: need_cp_fr, need_cp_eq
 
         computed_partials_ = .false.
         if (present(computed_partials)) computed_partials_ = computed_partials
@@ -2328,10 +2330,11 @@ contains
         soln%entropy = entropy_sum * R / 1.d3
         soln%gibbs_energy = (soln%enthalpy - soln%T*soln%entropy)
 
-        if (soln%cp_fr < 1.d-10) soln%cp_fr = dot_product(soln%thermo%cp, soln%nj) * R / 1.d3
-        if (.not. computed_partials_ .and. soln%cp_eq < 1.d-10) then
-            soln%cp_eq = dot_product(soln%thermo%cp, soln%nj) * R / 1.d3
-        end if
+        need_cp_fr = soln%cp_fr < 1.d-10
+        need_cp_eq = .not. computed_partials_ .and. soln%cp_eq < 1.d-10
+        if (need_cp_fr .or. need_cp_eq) cp_dot_nj = dot_product(soln%thermo%cp, soln%nj)
+        if (need_cp_fr) soln%cp_fr = cp_dot_nj * R / 1.d3
+        if (need_cp_eq) soln%cp_eq = cp_dot_nj * R / 1.d3
 
         ! Calculate molecular weights
         soln%M = 1.0d0/soln%n
@@ -4703,6 +4706,7 @@ contains
         ! Locals
         real(dp), allocatable :: J(:,:)
         real(dp) :: nj_solid ! Temporary variables for condensed species
+        real(dp) :: cp_dot_nj
         integer :: ng, ne, nc, na, ierr, i, idx, liq_rank
         integer, allocatable :: active_idx(:)
         real(dp), pointer :: nj(:), nj_g(:)     ! Total/gas species concentrations [kmol-per-kg]
@@ -4733,8 +4737,9 @@ contains
         self%cp_eq = 0.0d0
 
         ! Term 4: ∑_j^ns n_j*Cp_j/R
-        self%cp_eq = self%cp_eq + dot_product(soln%thermo%cp, soln%nj)
-        soln%cp_fr = dot_product(soln%thermo%cp, soln%nj)*(R/1.d3)
+        cp_dot_nj = dot_product(soln%thermo%cp, soln%nj)
+        self%cp_eq = self%cp_eq + cp_dot_nj
+        soln%cp_fr = cp_dot_nj*(R/1.d3)
 
         ! If both solid and liquid present, temporarily remove liquid to prevent singular matrix
         if (soln%j_sol /= 0) then

--- a/source/equilibrium.f90
+++ b/source/equilibrium.f90
@@ -1717,7 +1717,7 @@ contains
                         if (abs(d_phase) > 1) then
                             ! Switch phase
                             call log_info("Phase change: replace "//trim(self%products%species_names(ng+i))//&
-                                          " with "//self%products%species_names(ng+idx_other_phase(j)))
+                                          " with "//trim(self%products%species_names(ng+idx_other_phase(j))))
                             call soln%replace_active_condensed(i, idx_other_phase(j))
                             soln%nj(ng+idx_other_phase(j)) = soln%nj(ng+i)
                             soln%nj(ng+i) = 0.0d0
@@ -1756,7 +1756,7 @@ contains
                         if (soln%T < (T_low_i-dT_phase) .or. soln%T > (T_high_i+dT_phase)) then
                             ! Switch phase
                             call log_info("Phase change: replace "//trim(self%products%species_names(ng+i))//&
-                                          " with "//self%products%species_names(ng+idx_other_phase(j)))
+                                          " with "//trim(self%products%species_names(ng+idx_other_phase(j))))
                             call soln%replace_active_condensed(i, idx_other_phase(j))
                             soln%nj(ng+idx_other_phase(j)) = soln%nj(ng+i)
                             soln%nj(ng+i) = 0.0d0
@@ -1770,7 +1770,7 @@ contains
                         end if
 
                         ! else
-                        call log_debug("Adding "//self%products%species_names(ng+idx_other_phase(j)))
+                        call log_debug("Adding "//trim(self%products%species_names(ng+idx_other_phase(j))))
                         soln%T = min(T_high_i, T_high_j)  ! Set T as the melting temperature
                         if (T_high_i > T_high_j) then
                             soln%j_sol = idx_other_phase(j)
@@ -1795,7 +1795,7 @@ contains
 
             if (soln%T > 1.2d0*max_T_j) then
                 ! Remove condensed species
-                call log_info("Removing condensed species: "//self%products%species_names(ng+i))
+                call log_info("Removing condensed species: "//trim(self%products%species_names(ng+i)))
                 call soln%deactivate_condensed(i)
                 soln%nj(ng+i) = 0.0d0
                 soln%converged = .false.
@@ -1891,7 +1891,7 @@ contains
                 soln%nj(ng+cond_idx) = 0.0d0
                 soln%converged = .false.
                 iter = -1
-                call log_info("Removing "//self%products%species_names(ng+cond_idx))
+                call log_info("Removing "//trim(self%products%species_names(ng+cond_idx)))
                 return
             end if
 
@@ -1940,11 +1940,11 @@ contains
             soln%converged = .false.
             iter = -1
             soln%last_cond_idx = cond_idx
-            call log_info("Adding "//self%products%species_names(ng+cond_idx))
+            call log_info("Adding "//trim(self%products%species_names(ng+cond_idx)))
             return
         else
             call abort('EqSolver_test_condensed: Re-insertion of '// &
-                self%products%species_names(ng+singular_index_)//' likely to cause singular matrix.')
+                trim(self%products%species_names(ng+singular_index_))//' likely to cause singular matrix.')
         end if
 
     end subroutine
@@ -2019,7 +2019,7 @@ contains
             end do
             ! Remove condensed species contributing to singular matrix
             if (idx > 0) then
-                call log_info("Removing condensed species "//self%products%species_names(ng+idx)// &
+                call log_info("Removing condensed species "//trim(self%products%species_names(ng+idx))// &
                               " to correct singular matrix")
                 call soln%deactivate_condensed(idx)
                 soln%nj(ng+idx) = 0.0d0
@@ -2046,7 +2046,7 @@ contains
             end do
 
             if (idx > 0) then
-                call log_info("Removing condensed species "//self%products%species_names(ng+idx)// &
+                call log_info("Removing condensed species "//trim(self%products%species_names(ng+idx))// &
                               " to correct element-row singularity")
                 call soln%deactivate_condensed(idx)
                 soln%nj(ng+idx) = 0.0d0
@@ -3934,16 +3934,16 @@ contains
                 if (solution%nj(i) > 1.0d-10) then
                     abs_err = abs(self%dnj_dstate1_fd(i) - self%dnj_dstate1(i))
                     rel_err = abs_err / max(abs(self%dnj_dstate1(i)), 1.0d-30)
-                    write(*,*) "dnj/dstate1 (", solver%products%species_names(i), "): abs=", abs_err, " rel=", rel_err
+                    write(*,*) "dnj/dstate1 (", trim(solver%products%species_names(i)), "): abs=", abs_err, " rel=", rel_err
 
                     abs_err = abs(self%dnj_dstate2_fd(i) - self%dnj_dstate2(i))
                     rel_err = abs_err / max(abs(self%dnj_dstate2(i)), 1.0d-30)
-                    write(*,*) "dnj/dstate2 (", solver%products%species_names(i), "): abs=", abs_err, " rel=", rel_err
+                    write(*,*) "dnj/dstate2 (", trim(solver%products%species_names(i)), "): abs=", abs_err, " rel=", rel_err
 
                     if (nr > 0) then
                         abs_err = maxval(abs(self%dnj_dw0_fd(i, :) - self%dnj_dw0(i, :)))
                         rel_err = maxval(abs(self%dnj_dw0_fd(i, :) - self%dnj_dw0(i, :)) / max(abs(self%dnj_dw0(i, :)), 1.0d-30))
-                        write(*,*) "dnj/dw0 (", solver%products%species_names(i), ") (max): abs=", abs_err, " rel=", rel_err
+                        write(*,*) "dnj/dw0 (", trim(solver%products%species_names(i)), ") (max): abs=", abs_err, " rel=", rel_err
                     end if
                 end if
             end do
@@ -4197,7 +4197,7 @@ contains
                 if (j > 0) then
                     ! Only count this as an "insert" if it is condensed; no effect otherwise
                     if (solver%products%species(j)%i_phase > 0) then
-                        call log_info("Inserting "//solver%products%species_names(j))
+                        call log_info("Inserting "//trim(solver%products%species_names(j)))
                         call self%activate_condensed_front(j-solver%num_gas)
                     end if
                 end if
@@ -5356,7 +5356,7 @@ contains
                 selected_local_idx(j) = i
                 transport_to_local(idx(1)) = i
             else
-                call log_info('compute_transport_properties: Species '//eq_solver%products%species_names(idx_list(i))//&
+                call log_info('compute_transport_properties: Species '//trim(eq_solver%products%species_names(idx_list(i)))//&
                               ' not found in transport database.')
             end if
         end do

--- a/source/equilibrium_test.pf
+++ b/source/equilibrium_test.pf
@@ -4095,6 +4095,11 @@ contains
 
     @test
     subroutine test_equilibrium_transport_ch4_o2_smooth_truncation
+        ! Exercises the transport-species screening in compute_transport_properties under
+        ! smooth_truncation: trace species are revived via compute_nj_effective's smooth gate
+        ! (consistent with the rest of the smooth-truncation machinery) instead of always being
+        ! screened with a hard-zero check, so this confirms that path still yields physically
+        ! sane transport properties.
         type(Mixture) :: products
         type(Mixture) :: reactants
         type(EqSolver) :: solver
@@ -4117,6 +4122,102 @@ contains
 
         @assertTrue(solution%converged)
         @assertTrue(solution%T > 0.0d0)
+        @assertTrue(solution%viscosity > 0.0d0)
+        @assertTrue(solution%conductivity_fr > 0.0d0)
+        @assertTrue(solution%conductivity_eq > 0.0d0)
+        @assertTrue(solution%pr_fr > 0.0d0)
+        @assertTrue(solution%pr_eq > 0.0d0)
+    end subroutine
+
+    @test
+    subroutine test_transport_screening_smooth_gate_at_threshold
+        ! Isolated regression test for the equilibrium.f90 fix to the transport-species
+        ! screening loop in compute_transport_properties (issue djkees/cea#11).
+        !
+        ! A full second solve with smooth_truncation on would follow a different Newton
+        ! path than the hard-mode solve (smooth_truncation affects many other call sites
+        ! in the solve, not just this loop), so comparing two independent end-to-end
+        ! solves cannot isolate this one loop's behavior -- confirmed by checking that
+        ! such a comparison still passed against the pre-fix code. Instead, solve once,
+        ! then call compute_transport_properties directly on the same converged solution
+        ! with one species' ln_nj forced exactly to its activity threshold and nj forced
+        ! to zero -- first with smooth_truncation off, then on. The only thing that
+        ! differs between the two direct calls is the gate itself.
+        type(Mixture) :: products
+        type(Mixture) :: reactants
+        type(EqSolver) :: solver
+        type(EqSolution) :: soln
+        character(:), allocatable :: product_names(:)
+        real(dp) :: h_reac, p_reac, weights(2)
+        real(dp) :: ln_threshold
+        integer :: idx(1), i
+
+        reactants = Mixture(all_thermo, ['CH4', 'O2 '])
+        product_names = reactants%get_products(all_thermo)
+        products = Mixture(all_thermo, product_names)
+
+        solver = EqSolver(products, reactants, all_transport=all_transport)
+        soln = EqSolution(solver)
+
+        weights = reactants%weights_from_of([0.0d0, 1.0d0], [1.0d0, 0.0d0], 2.6d0)
+        h_reac = reactants%calc_enthalpy(weights, [298.15d0, 298.15d0])/R
+        p_reac = psi_to_bar(1000.0d0)
+
+        call solver%solve(soln, 'hp', h_reac, p_reac, weights)
+        @assertTrue(soln%converged)
+
+        ! Perturb the smallest-amount gas species so overwriting it doesn't disturb
+        ! the dominant-species mass balance used elsewhere in the routine.
+        idx = minloc(soln%nj(:solver%num_gas))
+        i = idx(1)
+
+        ln_threshold = log(soln%n) - solver%tsize
+        soln%nj(i) = 0.0d0
+        soln%ln_nj(i) = ln_threshold
+
+        solver%smooth_truncation = .false.
+        call compute_transport_properties(solver, soln)
+        @assertEqual(0.0d0, soln%nj(i))
+
+        solver%smooth_truncation = .true.
+        call compute_transport_properties(solver, soln)
+        @assertTrue(soln%nj(i) > 0.0d0)
+    end subroutine
+
+    @test
+    subroutine test_equilibrium_transport_ionized_smooth_truncation
+        ! Exercises the ion-aware branch (esize threshold instead of tsize) of the
+        ! transport-species screening loop, combined with smooth_truncation. This
+        ! combination -- ions + transport + smooth_truncation together -- was not
+        ! otherwise covered: test_ionized_smooth_truncation exercises ions with
+        ! smooth_truncation but without transport enabled, so it never reaches
+        ! compute_transport_properties at all.
+        type(Mixture) :: products
+        type(Mixture) :: reactants
+        type(EqSolver) :: solver
+        type(EqSolution) :: soln
+        character(snl), allocatable :: product_names(:)
+        real(dp) :: p_reac, t_reac, weights(1)
+
+        reactants = Mixture(all_thermo, ['Air'], ions=.true.)
+        product_names = reactants%get_products(all_thermo, omit=["C(gr)"])
+        products = Mixture(all_thermo, product_names, ions=.true.)
+
+        solver = EqSolver(products, reactants, ions=.true., all_transport=all_transport, smooth_truncation=.true.)
+        soln = EqSolution(solver)
+
+        weights = [1.0d0]
+        t_reac = 5000.0d0
+        p_reac = 0.0101325d0
+
+        call solver%solve(soln, 'tp', t_reac, p_reac, weights)
+
+        @assertTrue(soln%converged)
+        @assertTrue(soln%viscosity > 0.0d0)
+        @assertTrue(soln%conductivity_fr > 0.0d0)
+        @assertTrue(soln%conductivity_eq > 0.0d0)
+        @assertTrue(soln%pr_fr > 0.0d0)
+        @assertTrue(soln%pr_eq > 0.0d0)
     end subroutine
 
     @test

--- a/source/mixture.f90
+++ b/source/mixture.f90
@@ -752,13 +752,14 @@ contains
 
         ! Locals
         integer :: j
-        real(dp) :: hj, nj
+        real(dp) :: hj, nj, total_weight
 
         call check_array_len(size(weights), self%num_species, 'mixture_calc_enthalpy_single weights')
 
+        total_weight = sum(weights)
         h = 0.0d0
         do j = 1, self%num_species
-            nj = weights(j)/self%species(j)%molecular_weight/sum(weights)
+            nj = weights(j)/self%species(j)%molecular_weight/total_weight
             hj = self%species(j)%calc_enthalpy(temperature)
             h = h + nj*hj
         end do
@@ -778,14 +779,15 @@ contains
 
         ! Locals
         integer :: j
-        real(dp) :: hj, nj
+        real(dp) :: hj, nj, total_weight
 
         call check_array_len(size(weights), self%num_species, 'mixture_calc_enthalpy_multi weights')
         call check_array_len(size(temperatures), self%num_species, 'mixture_calc_enthalpy_multi temperatures')
 
+        total_weight = sum(weights)
         h = 0.0d0
         do j = 1, self%num_species
-            nj = weights(j)/self%species(j)%molecular_weight/sum(weights)
+            nj = weights(j)/self%species(j)%molecular_weight/total_weight
             hj = self%species(j)%calc_enthalpy(temperatures(j))
             h = h + nj*hj
         end do
@@ -841,14 +843,15 @@ contains
 
         ! Locals
         integer :: j
-        real(dp) :: sj, nj, n
+        real(dp) :: sj, nj, n, total_weight
 
         call check_array_len(size(weights), self%num_species, 'mixture_calc_entropy_single weights')
 
+        total_weight = sum(weights)
         n = 0.0d0
         s = 0.0d0
         do j = 1, self%num_species
-            nj = weights(j)/self%species(j)%molecular_weight/sum(weights)
+            nj = weights(j)/self%species(j)%molecular_weight/total_weight
             if (nj < 1e-35) cycle
             sj = self%species(j)%calc_entropy(temperature)
             if (self%is_condensed(j)) then
@@ -876,16 +879,17 @@ contains
 
         ! Locals
         integer :: j
-        real(dp) :: sj, nj, n
+        real(dp) :: sj, nj, n, total_weight
 
         call check_array_len(size(weights), self%num_species, 'mixture_calc_entropy_multi weights')
         call check_array_len(size(temperatures), self%num_species, 'mixture_calc_entropy_multi temperatures')
         call check_array_len(size(pressures), self%num_species, 'mixture_calc_entropy_multi pressures')
 
+        total_weight = sum(weights)
         n = 0.0d0
         s = 0.0d0
         do j = 1, self%num_species
-            nj = weights(j)/self%species(j)%molecular_weight/sum(weights)
+            nj = weights(j)/self%species(j)%molecular_weight/total_weight
             if (nj < 1e-35) cycle
             sj = self%species(j)%calc_entropy(temperatures(j))
             if (self%is_condensed(j)) then
@@ -974,13 +978,14 @@ contains
 
         ! Locals
         integer :: j
-        real(dp) :: cpj, nj
+        real(dp) :: cpj, nj, total_weight
 
         call check_array_len(size(weights), self%num_species, 'mixture_calc_frozen_cp_single weights')
 
+        total_weight = sum(weights)
         cp = 0.0d0
         do j = 1, self%num_species
-            nj  = weights(j)/self%species(j)%molecular_weight/sum(weights)
+            nj  = weights(j)/self%species(j)%molecular_weight/total_weight
             cpj = self%species(j)%calc_cp(temperature)
             cp  = cp + nj*cpj
         end do
@@ -1000,14 +1005,15 @@ contains
 
         ! Locals
         integer :: j
-        real(dp) :: cpj, nj
+        real(dp) :: cpj, nj, total_weight
 
         call check_array_len(size(weights), self%num_species, 'mixture_calc_frozen_cp_multi weights')
         call check_array_len(size(temperatures), self%num_species, 'mixture_calc_frozen_cp_multi temperatures')
 
+        total_weight = sum(weights)
         cp = 0.0d0
         do j = 1, self%num_species
-            nj  = weights(j)/self%species(j)%molecular_weight/sum(weights)
+            nj  = weights(j)/self%species(j)%molecular_weight/total_weight
             cpj = self%species(j)%calc_cp(temperatures(j))
             cp  = cp + nj*cpj
         end do
@@ -1027,13 +1033,14 @@ contains
 
         ! Locals
         integer :: j
-        real(dp) :: cvj, nj
+        real(dp) :: cvj, nj, total_weight
 
         call check_array_len(size(weights), self%num_species, 'mixture_calc_frozen_cv_single weights')
 
+        total_weight = sum(weights)
         cv = 0.0d0
         do j = 1, self%num_species
-            nj  = weights(j)/self%species(j)%molecular_weight/sum(weights)
+            nj  = weights(j)/self%species(j)%molecular_weight/total_weight
             cvj = self%species(j)%calc_cv(temperature)
             cv  = cv + nj*cvj
         end do
@@ -1053,14 +1060,15 @@ contains
 
         ! Locals
         integer :: j
-        real(dp) :: cvj, nj
+        real(dp) :: cvj, nj, total_weight
 
         call check_array_len(size(weights), self%num_species, 'mixture_calc_frozen_cv_multi weights')
         call check_array_len(size(temperatures), self%num_species, 'mixture_calc_frozen_cv_multi temperatures')
 
+        total_weight = sum(weights)
         cv = 0.0d0
         do j = 1, self%num_species
-            nj  = weights(j)/self%species(j)%molecular_weight/sum(weights)
+            nj  = weights(j)/self%species(j)%molecular_weight/total_weight
             cvj = self%species(j)%calc_cv(temperatures(j))
             cv  = cv + nj*cvj
         end do

--- a/source/mixture.f90
+++ b/source/mixture.f90
@@ -861,8 +861,8 @@ contains
                 s = s + nj*(sj - log(nj))
             end if
         end do
-        s = s - n*log(pressure/n)
-        s = s * gas_constant !/ 1.d3
+        s = s - n*log(pressure/std_pressure/n)
+        s = s * gas_constant
 
     end function
 
@@ -896,11 +896,11 @@ contains
                 s = s + nj*sj
             else
                 n = n + nj
-                s = s + nj*(sj - log(nj*pressures(j)))
+                s = s + nj*(sj - log(nj*pressures(j)/std_pressure))
             end if
         end do
         s = s + n*log(n)
-        s = s * gas_constant / 1.d3
+        s = s * gas_constant
 
     end function
 
@@ -935,24 +935,26 @@ contains
 
         ! Locals
         integer :: j
-        real(dp) :: gj, nj, n, nr, pr
+        real(dp) :: gj, nj, n, nr, pr, total_weight
 
         call check_array_len(size(weights), self%num_species, 'mixture_calc_gibbs_energy_multi weights')
         call check_array_len(size(temperatures), self%num_species, 'mixture_calc_gibbs_energy_multi temperatures')
         call check_array_len(size(pressures), self%num_species, 'mixture_calc_gibbs_energy_multi pressures')
+
+        total_weight = sum(weights)
 
         ! Must pre-compute because cannot factor out of the
         ! sum when consitituent temperatures can vary.
         n = 0.0d0
         do j = 1, self%num_species
             if (self%is_condensed(j)) cycle
-            nj = weights(j)/self%species(j)%molecular_weight
+            nj = weights(j)/self%species(j)%molecular_weight/total_weight
             n = n + nj
         end do
 
         g = 0.0d0
         do j = 1, self%num_species
-            nj = weights(j)/self%species(j)%molecular_weight
+            nj = weights(j)/self%species(j)%molecular_weight/total_weight
             gj = self%species(j)%calc_gibbs_energy(temperatures(j))
             if (self%is_condensed(j)) then
                 g = g + nj*gj

--- a/source/mixture_test.pf
+++ b/source/mixture_test.pf
@@ -329,16 +329,16 @@ contains
         t = temp(1)
         @assertRelativelyEqual(-1.19532599d+07, mix%calc_enthalpy(wtfracs, t), tol)
         @assertRelativelyEqual(-1.20517040d+07, mix%calc_energy(wtfracs, t), tol)
-        !@assertRelativelyEqual(-1.48300159E+07, mix%calc_gibbs_energy(wtfracs, t, p), tol)
-        !@assertRelativelyEqual( 9.46301312d+03, mix%calc_entropy(wtfracs, t, p), tol)
+        @assertRelativelyEqual(-1.48300159E+07, mix%calc_gibbs_energy(wtfracs, t, p), tol)
+        @assertRelativelyEqual( 9.46301312d+03, mix%calc_entropy(wtfracs, t, p), tol)
 
         ! Version 2: Allow per-species temperatures and pressures
         ! This enables fuels and oxidizers to have different initial states
         ! prior to being mixed and equilibrated.
         @assertRelativelyEqual(-1.19532599d+07, mix%calc_enthalpy(wtfracs, temp), tol)
         @assertRelativelyEqual(-1.20517040d+07, mix%calc_energy(wtfracs, temp), tol)
-        !@assertRelativelyEqual(-1.48300159E+07, mix%calc_gibbs_energy(wtfracs, temp, pres), tol)
-        !@assertRelativelyEqual( 9.46301312d+03, mix%calc_entropy(wtfracs, temp, pres), tol)
+        @assertRelativelyEqual(-1.48300159E+07, mix%calc_gibbs_energy(wtfracs, temp, pres), tol)
+        @assertRelativelyEqual( 9.46301312d+03, mix%calc_entropy(wtfracs, temp, pres), tol)
 
     end subroutine
 

--- a/source/rocket.f90
+++ b/source/rocket.f90
@@ -893,7 +893,7 @@ contains
             if (supar(i) < 2.0d0) then
                 ln_pinf_pe = ln_pinf_pt + sqrt(3.294d0*(log(supar(i))**2.0d0) + 1.535d0*log(supar(i)))
             else if (supar(i) >= 2.0d0) then
-                ln_pinf_pe = soln%eq_partials(2)%gamma_s + 1.4d0*log(supar(i))
+                ln_pinf_pe = soln%eq_partials(soln%throat_idx)%gamma_s + 1.4d0*log(supar(i))
             end if
 
             do j = 1, max_iter_area
@@ -987,7 +987,7 @@ contains
             if (supar(i) < 2.0d0) then
                 ln_pinf_pe = ln_pinf_pt + sqrt(3.294d0*(log(supar(i))**2.0d0) + 1.535d0*log(supar(i)))
             else if (supar(i) >= 2.0d0) then
-                ln_pinf_pe = soln%eq_partials(2)%gamma_s + 1.4d0*log(supar(i))
+                ln_pinf_pe = soln%eq_partials(soln%throat_idx)%gamma_s + 1.4d0*log(supar(i))
             end if
 
             do j = 1, max_iter_area

--- a/source/shock.f90
+++ b/source/shock.f90
@@ -616,6 +616,10 @@ contains
         call soln%eq_soln(idx)%constraints%set(type, T0, P0, &
             self%eq_solver%reactants%element_amounts_from_weights(weights))
 
+        ! Compute the molecular weight of the initial mixture
+        wm = sum(weights)
+        wm_k = wm
+
         ! Set the reactant weights as the species amount
         soln%eq_soln(idx)%converged = .true.
         soln%eq_soln(idx)%nj(:) = 0.0d0
@@ -623,7 +627,7 @@ contains
         do i = 1, self%eq_solver%num_reactants
             j = findloc(self%eq_solver%products%species_names, self%eq_solver%reactants%species_names(i), 1)
             if (j > 0) then
-                soln%eq_soln(idx)%nj(j) = (weights(i)/self%eq_solver%reactants%species(i)%molecular_weight)/sum(weights)
+                soln%eq_soln(idx)%nj(j) = (weights(i)/self%eq_solver%reactants%species(i)%molecular_weight)/wm
                 soln%eq_soln(idx)%ln_nj(j) = log(soln%eq_soln(idx)%nj(j))
             else
                 call log_warning("ShockSolver_solve_incident_frozen: Reactant not found in products.")
@@ -632,10 +636,6 @@ contains
 
         soln%eq_partials(idx)%dlnV_dlnP = -1.0d0
         soln%eq_partials(idx)%dlnV_dlnT = 1.0d0
-
-        ! Compute the molecular weight of the initial mixture
-        wm = sum(weights)
-        wm_k = wm
         soln%eq_soln(idx)%n = 1.0d0/wm
 
         ! Compute properties of the initial mixture
@@ -1127,7 +1127,7 @@ contains
             j = findloc(self%eq_solver%products%species_names, self%eq_solver%reactants%species_names(i), 1)
             if (j > 0) then
                 soln%eq_soln(1)%nj(j) = (reactant_weights(i)/ &
-                    self%eq_solver%reactants%species(i)%molecular_weight)/sum(reactant_weights)
+                    self%eq_solver%reactants%species(i)%molecular_weight)/wm
                 soln%eq_soln(1)%ln_nj(j) = log(soln%eq_soln(1)%nj(j))
             else
                 call log_warning("ShockSolver_solve_incident_frozen: Reactant not found in products.")

--- a/source/shock.f90
+++ b/source/shock.f90
@@ -725,7 +725,7 @@ contains
 
     end subroutine
 
-    subroutine ShockSolver_solve_reflected(self, soln, weights, T0, P0)
+    subroutine ShockSolver_solve_reflected(self, soln, weights, T0)
         ! Solve the reflected shock conditions
 
         ! Arguments
@@ -733,7 +733,6 @@ contains
         class(ShockSolution), intent(inout) :: soln
         real(dp), intent(in) :: weights(:)
         real(dp), intent(in) :: T0                     ! Initial reactant temperature [K]
-        real(dp), intent(in) :: P0                     ! Initial reactant pressure [bar]
 
         ! Locals
         integer :: idx  ! Solution index for the incident conditions
@@ -758,7 +757,6 @@ contains
         real(dp), parameter :: T_gas_max = 20000.d0  ! Max gas temperature in the thermo database [K]
 
         ! Initialize
-        if (.false.) print *, P0
         idx = 3
         G = 0.0d0  ! Reset the matrix
         soln%converged = .false.
@@ -1158,7 +1156,7 @@ contains
             if (reflected_frozen_) then
                 call self%solve_reflected_frozen(soln, reactant_weights, T0, P0)
             else  ! Equilibrium
-                call self%solve_reflected(soln, reactant_weights, T0, P0)
+                call self%solve_reflected(soln, reactant_weights, T0)
             end if
             if (soln%eq_soln(3)%T <= 0.0d0) then
                 return

--- a/source/thermo.f90
+++ b/source/thermo.f90
@@ -128,11 +128,27 @@ contains
         end if
     end subroutine
 
+    elemental function st_select_interval(self, T) result(idx)
+        !! Select the index of the temperature-fit interval containing T
+        class(SpeciesThermo), intent(in) :: self
+        real(dp), intent(in) :: T
+        integer :: idx
+        integer :: i
+
+        idx = 1
+        do i = 1,self%num_intervals
+            if (T > self%T_fit(i, 1)) then
+                idx = i
+            end if
+        end do
+
+    end function
+
     elemental function st_calc_cv(self, T) result(cv)
         class(SpeciesThermo), intent(in) :: self
         real(dp), intent(in) :: T
         real(dp) :: cv
-        integer :: i, idx
+        integer :: idx
 
         if (.not. allocated(self%fits)) then
             cv = 0.0d0
@@ -140,12 +156,7 @@ contains
         end if
 
         ! Select temperature range
-        idx = 1
-        do i = 1,self%num_intervals
-            if (T > self%T_fit(i, 1)) then
-                idx = i
-            end if
-        end do
+        idx = st_select_interval(self, T)
 
         ! Evaluate selected fit
         cv = self%fits(idx)%calc_cv(T)
@@ -156,7 +167,7 @@ contains
         class(SpeciesThermo), intent(in) :: self
         real(dp), intent(in) :: T
         real(dp) :: cp
-        integer :: i, idx
+        integer :: idx
 
         if (.not. allocated(self%fits)) then
             cp = 0.0d0
@@ -164,12 +175,7 @@ contains
         end if
 
         ! Select temperature range
-        idx = 1
-        do i = 1,self%num_intervals
-            if (T > self%T_fit(i, 1)) then
-                idx = i
-            end if
-        end do
+        idx = st_select_interval(self, T)
 
         ! Evaluate selected fit
         cp = self%fits(idx)%calc_cp(T)
@@ -180,7 +186,7 @@ contains
         class(SpeciesThermo), intent(in) :: self
         real(dp), intent(in) :: T
         real(dp) :: u_R
-        integer :: i, idx
+        integer :: idx
 
         if (.not. allocated(self%fits)) then
             u_R = self%calc_enthalpy(T) - T
@@ -188,12 +194,7 @@ contains
         end if
 
         ! Select temperature range
-        idx = 1
-        do i = 1,self%num_intervals
-            if (T > self%T_fit(i, 1)) then
-                idx = i
-            end if
-        end do
+        idx = st_select_interval(self, T)
 
         ! Evaluate selected fit
         u_R = self%fits(idx)%calc_energy(T, log(T))
@@ -204,17 +205,12 @@ contains
         class(SpeciesThermo), intent(in) :: self
         real(dp), intent(in) :: T
         real(dp) :: h_R
-        integer :: i, idx
+        integer :: idx
 
         if (allocated(self%fits)) then
 
             ! Select temperature range
-            idx = 1
-            do i = 1,self%num_intervals
-                if (T > self%T_fit(i, 1)) then
-                    idx = i
-                end if
-            end do
+            idx = st_select_interval(self, T)
 
             ! Evaluate selected fit
             h_R = self%fits(idx)%calc_enthalpy(T, log(T))
@@ -229,7 +225,7 @@ contains
         class(SpeciesThermo), intent(in) :: self
         real(dp), intent(in) :: T
         real(dp) :: s_R
-        integer :: i, idx
+        integer :: idx
 
         if (.not. allocated(self%fits)) then
             s_R = 0.0d0
@@ -237,12 +233,7 @@ contains
         end if
 
         ! Select temperature range
-        idx = 1
-        do i = 1,self%num_intervals
-            if (T > self%T_fit(i, 1)) then
-                idx = i
-            end if
-        end do
+        idx = st_select_interval(self, T)
 
         ! Evaluate selected fit
         s_R = self%fits(idx)%calc_entropy(T, log(T))
@@ -253,7 +244,7 @@ contains
         class(SpeciesThermo), intent(in) :: self
         real(dp), intent(in) :: T
         real(dp) :: g
-        integer :: i, idx
+        integer :: idx
 
         if (.not. allocated(self%fits)) then
             g = self%calc_enthalpy(T)
@@ -261,12 +252,7 @@ contains
         end if
 
         ! Select temperature range
-        idx = 1
-        do i = 1,self%num_intervals
-            if (T > self%T_fit(i, 1)) then
-                idx = i
-            end if
-        end do
+        idx = st_select_interval(self, T)
 
         ! Evaluate selected fit
         g = self%fits(idx)%calc_gibbs_energy(T, log(T))
@@ -306,15 +292,10 @@ contains
         class(SpeciesThermo), intent(in) :: self
         real(dp), intent(in) :: T
         real(dp) :: dcv_dT
-        integer :: i, idx
+        integer :: idx
 
         ! Select temperature range
-        idx = 1
-        do i = 1,self%num_intervals
-            if (T > self%T_fit(i, 1)) then
-                idx = i
-            end if
-        end do
+        idx = st_select_interval(self, T)
 
         ! Evaluate selected fit
         dcv_dT = self%fits(idx)%calc_dcv_dT(T)
@@ -325,15 +306,10 @@ contains
         class(SpeciesThermo), intent(in) :: self
         real(dp), intent(in) :: T
         real(dp) :: dcp_dT
-        integer :: i, idx
+        integer :: idx
 
         ! Select temperature range
-        idx = 1
-        do i = 1,self%num_intervals
-            if (T > self%T_fit(i, 1)) then
-                idx = i
-            end if
-        end do
+        idx = st_select_interval(self, T)
 
         ! Evaluate selected fit
         dcp_dT = self%fits(idx)%calc_dcp_dT(T)
@@ -344,15 +320,10 @@ contains
         class(SpeciesThermo), intent(in) :: self
         real(dp), intent(in) :: T
         real(dp) :: du_dT
-        integer :: i, idx
+        integer :: idx
 
         ! Select temperature range
-        idx = 1
-        do i = 1,self%num_intervals
-            if (T > self%T_fit(i, 1)) then
-                idx = i
-            end if
-        end do
+        idx = st_select_interval(self, T)
 
         ! Evaluate selected fit
         du_dT = self%fits(idx)%calc_denergy_dT(T)
@@ -363,15 +334,10 @@ contains
         class(SpeciesThermo), intent(in) :: self
         real(dp), intent(in) :: T
         real(dp) :: dh_dT
-        integer :: i, idx
+        integer :: idx
 
         ! Select temperature range
-        idx = 1
-        do i = 1,self%num_intervals
-            if (T > self%T_fit(i, 1)) then
-                idx = i
-            end if
-        end do
+        idx = st_select_interval(self, T)
 
         ! Evaluate selected fit
         dh_dT = self%fits(idx)%calc_denthalpy_dT(T)
@@ -382,15 +348,10 @@ contains
         class(SpeciesThermo), intent(in) :: self
         real(dp), intent(in) :: T
         real(dp) :: ds_dT
-        integer :: i, idx
+        integer :: idx
 
         ! Select temperature range
-        idx = 1
-        do i = 1,self%num_intervals
-            if (T > self%T_fit(i, 1)) then
-                idx = i
-            end if
-        end do
+        idx = st_select_interval(self, T)
 
         ! Evaluate selected fit
         ds_dT = self%fits(idx)%calc_dentropy_dT(T)

--- a/test/main_interface/test_main.py
+++ b/test/main_interface/test_main.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import subprocess
+import sys
 import warnings
 import csv
 from pathlib import Path
@@ -580,3 +581,5 @@ with open("test_results.csv", "w", newline="") as csv_file:
     writer.writerow(["test_name", "value_type", "variable", "value", "reference", "abs_error", "rel_error"])
     for row in zip(test_names_csv, value_type, variable, value, reference, abs_error, rel_error):
         writer.writerow(row)
+
+sys.exit(0 if passed_count == num_tests else 1)


### PR DESCRIPTION
## Summary

`eq_solve` (both the compiled `cea.lib.libcea.eq_solve` and the `cea.matlab.eq_solve` wrapper on top of it) computed `state1` for HP/SP/UV problems without dividing by the gas constant `R`, while every other call site in the codebase that computes the same quantity (e.g. `cea.matlab`'s `rocket_solve`) divides by `R` first. The result was a silently wrong, non-converged solve for any HP/SP/UV problem driven through `T_reac` or `H=`/`S=`/`U=`.

Example: an H2/O2 adiabatic-flame-temperature solve at `T_reac=1000 K` should converge to ~3155 K, but previously returned `converged=False, T=76217.8 K` with a Fortran-side "temperature outside allowable bounds" warning.

## Changes

- `source/bind/python/CEA.pyx`: divide `state1` by a new `GAS_CONSTANT` module constant (8314.51 J/(kmol·K), matching `cea_param.gas_constant`) for HP/SP/SV/UV, both when `H`/`S`/`U` are passed directly and when `state1` is computed via `T_reac`.
- Updated the `eq_solve` docstring to note the internal `/R` conversion.
- `source/bind/python/tests/test_matlab_wrapper.py`: added a regression test covering both the `T_reac`-driven and direct-`H=` paths.

## Testing
- `pytest source/bind/python/tests -q` — 116 passed (up from 115)
- Manually reproduced the bug: `cea.matlab.eq_solve(cea.HP, ..., T_reac=1000.0, ...)` previously returned `converged=False, T=76217.8K`; now converges to `T=3155.49K`, matching a manual `h0/R` calculation.
- Also verified the direct `H=` path (broken the same way, but not exercised by the T_reac reproduction) now converges to the identical result as the `T_reac` path.

## Compatibility / Numerical behavior
- [x] Expected changes (explain and provide validation)
  - Intentionally changes `eq_solve`'s output for HP/SP/SV/UV problems driven via `T_reac` or `H=`/`S=`/`U=` — the previous output was non-convergent/non-physical. TP/TV problems (`state1=T`) are unaffected. Validated against a manual low-level `EqSolver.solve` call using the correct `h0/R` convention, and against `source/equilibrium.f90:1464`, which confirms the core expects `state1` in the `H/R` convention.

---
Drafted with Claude's assistance
- Confirmed numerically: reproduced the reported bug case, applied the fix, and re-verified it converges to the physically expected temperature.
- Cross-checked the expected `state1` convention against `source/equilibrium.f90:1464` and the existing `/R` pattern in `cea.matlab`'s `rocket_solve`.
- Ran the full Python test suite (116 passed) after the fix.