### PR TITLE
Fail loudly instead of skipping cea_module fixture on broken CI builds

### DIFF
--- a/source/bind/python/tests/conftest.py
+++ b/source/bind/python/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from pathlib import Path
 
@@ -5,16 +6,26 @@ import pytest
 
 PROJECT_PYTHON_DIR = Path(__file__).resolve().parents[1]
 
+# In CI, this fixture is exercising a build CI just produced, so an import or
+# init failure is a real failure, not an optional/environment-dependent skip.
+_IN_CI = bool(os.environ.get("CI") or os.environ.get("GITHUB_ACTIONS"))
+
+
+def _skip_or_fail(message):
+    if _IN_CI:
+        pytest.fail(message)
+    pytest.skip(message)
+
 
 @pytest.fixture(scope="session")
 def cea_module():
     try:
         import cea
     except Exception as exc:
-        pytest.skip(f"cea import failed: {exc}")
+        _skip_or_fail(f"cea import failed: {exc}")
     try:
         if hasattr(cea, "is_initialized") and not cea.is_initialized():
-            pytest.skip("cea database not initialized")
+            _skip_or_fail("cea database not initialized")
     except Exception as exc:
-        pytest.skip(f"cea initialization check failed: {exc}")
+        _skip_or_fail(f"cea initialization check failed: {exc}")
     return cea


### PR DESCRIPTION
## Summary

The session-scoped `cea_module` pytest fixture in `source/bind/python/tests/conftest.py`, which nearly every Python test depends on, called `pytest.skip(...)` when `import cea` or `cea.is_initialized()` failed. A broken build (compile failure, missing extension, botched CMake step) made every dependent test report "skipped" rather than "failed," and pytest exits 0 on an all-skipped run — so `basic_build.yml`'s `python-tests` job could show green even though nothing actually ran.

https://github.com/djkees/cea/issues/89

## Changes

- `conftest.py`: the fixture now checks the `CI`/`GITHUB_ACTIONS` environment variables (set automatically by GitHub Actions runners). When set, an import or init failure calls `pytest.fail(...)` instead of `pytest.skip(...)`, so the run errors out with a nonzero exit code. Outside CI (e.g. local dev without a built extension), the original skip behavior is unchanged.

## Testing
- `pytest source/bind/python/tests -q` (real dev environment, extension built): 116 passed, confirming no regression.
- Manual before/after check with a throwaway test that poisons `sys.modules["cea"]` to force an import failure: without `CI` set, `1 skipped` (unchanged); with `CI=true`, `1 error` / `Failed: cea import failed: ...` (new behavior).

## Compatibility / Numerical behavior
- [x] No expected changes to numerical results

Test-infrastructure only; no solver/binding logic touched.

---
Drafted with Claude's assistance
- Verified by reading the original `conftest.py` and reproducing both the old (skip) and new (fail) behavior directly, in both a clean sandbox and a real dev environment, before and after the change.
- Full existing Python test suite (116 tests) re-run and confirmed passing after the change.