### PR TITLE
Document Windows shell quirks for AI agents in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,33 @@ When modifying Python bindings:
 4. Test command: `pytest source/bind/python/tests`
 5. Ensure `numpy` is installed in the active Python environment
 
+### Windows: AI Agent Shell Sessions
+
+AI coding agents typically run each shell command as an independent,
+non-interactive process. On Windows this creates friction that a human
+running one persistent terminal never sees:
+
+- **PATH/environment activation does not persist between commands.**
+  `conda activate <env>` (see `environment.yml` for the env name) only
+  affects the process it runs in. Since cmake, gfortran, and ctest are
+  commonly installed only inside that conda environment on Windows, each
+  individual command that needs them must activate the environment or
+  prepend its `Library/bin`, base, and `Scripts` directories to `PATH`
+  within that same command — don't assume a prior "activate" call carries
+  forward to the next one.
+- **Avoid `python3` in Git Bash.** Windows intercepts unqualified
+  `python3` calls with an app-execution alias that prompts to install
+  Python from the Microsoft Store instead of running the real
+  interpreter. Use `python` instead.
+- **Avoid heredoc-to-stdin patterns in Git Bash** (e.g. `cmd <<'EOF'
+  ... EOF` piped via `/dev/stdin`, or `cmd | python -c "..."` relying on
+  piped stdin through `/proc/self/fd/0`). Git Bash's stdin/fd emulation
+  is unreliable for this on Windows; write the input to a temp file and
+  reference that instead.
+- If a build tool isn't found on PATH, check the project's conda
+  environment directory directly rather than running a broad filesystem
+  search — those are slow and prone to timing out.
+
 ## Testing
 
 - **Run existing tests** before and after changes


### PR DESCRIPTION
## Summary

Adds a short "Windows: AI Agent Shell Sessions" subsection to CLAUDE.md's Build System section, documenting shell-environment quirks specific to AI coding agents (like Claude Code) working on this repo on Windows.

## Changes

- New subsection under `## Build System` covering: PATH/conda-activation not persisting across independent agent shell invocations, the `python3` Windows Store alias interception, unreliable `/dev/stdin` heredoc patterns in Git Bash, and preferring a direct conda-env-directory lookup over a broad filesystem search when a build tool isn't found.
- No changes to CONTRIBUTING.md, README.md, or any other doc — this is agent-facing guidance, distinct from the human-facing setup instructions already correct in `docs/source/developer_guide.rst`.
- Already reviewed and merged on the fork: https://github.com/djkees/cea/pull/210

## Testing

- Not run (explain why): documentation-only change, no code paths affected.

## Compatibility / Numerical behavior

- [x] No expected changes to numerical results

---

Drafted with Claude's assistance.
- Confirmed `docs/source/developer_guide.rst:66` already correctly instructs human contributors to run `conda activate cea-dev`, so this addition targets agent-specific friction rather than duplicating or contradicting existing docs.
- The specific failure modes described (PATH not persisting, `python3` alias interception, `/dev/stdin` heredoc failures) were observed directly in this repo's own recent Claude Code session transcripts, not inferred.