### PR TITLE
Fix unfailable 1.0d30 tolerances in hp/sp/uv/sv derivative FD tests

### DIFF
--- a/source/equilibrium_test.pf
+++ b/source/equilibrium_test.pf
@@ -1295,7 +1295,7 @@ contains
         type(EqDerivatives) :: totals
         real(dp) :: h_reac, p_reac, weights(2)
         real(dp), parameter :: h = 1.0d-6
-        real(dp), parameter :: tol = 1.0d30
+        real(dp), parameter :: tol = 5.0d-2
         real(dp) :: rel
         ! integer :: i
 
@@ -1349,12 +1349,13 @@ contains
               max(max(abs(totals%dH_dstate1_fd), abs(totals%dH_dstate1)), 1.0d-8)
         ! write(*,*) "dH/dstate1: an=", totals%dH_dstate1, " fd=", totals%dH_dstate1_fd, " rel=", rel
         @assertLessThan(rel, tol)
+        ! dH/dstate2 = 0 for hp (H is pinned regardless of P); floor absorbs FD noise here when there's no real error to detect
         rel = abs(totals%dH_dstate2_fd - totals%dH_dstate2) / &
-              max(max(abs(totals%dH_dstate2_fd), abs(totals%dH_dstate2)), 1.0d-8)
+              max(max(abs(totals%dH_dstate2_fd), abs(totals%dH_dstate2)), 1.0d-3)
         ! write(*,*) "dH/dstate2: an=", totals%dH_dstate2, " fd=", totals%dH_dstate2_fd, " rel=", rel
         @assertLessThan(rel, tol)
         rel = maxval(abs(totals%dH_dw0_fd - totals%dH_dw0) / &
-                     max(max(abs(totals%dH_dw0_fd), abs(totals%dH_dw0)), 1.0d-8))
+                     max(max(abs(totals%dH_dw0_fd), abs(totals%dH_dw0)), 1.0d-1))
         ! do i = 1, solver%num_reactants
             ! write(*,*) "dH/dw0(", i, "): an=", totals%dH_dw0(i), " fd=", totals%dH_dw0_fd(i)
         ! end do
@@ -1423,7 +1424,7 @@ contains
         type(EqDerivatives) :: totals
         real(dp) :: h_reac, p_reac, weights(2)
         real(dp), parameter :: h = 1.0d-6
-        real(dp), parameter :: tol = 1.0d30
+        real(dp), parameter :: tol = 5.0d-2
         real(dp) :: rel
         integer :: i
 
@@ -1477,12 +1478,13 @@ contains
               max(max(abs(totals%dH_dstate1_fd), abs(totals%dH_dstate1)), 1.0d-8)
         write(*,*) "dH/dstate1: an=", totals%dH_dstate1, " fd=", totals%dH_dstate1_fd, " rel=", rel
         @assertLessThan(rel, tol)
+        ! dH/dstate2 = 0 for hp (H is pinned regardless of P); floor absorbs FD noise here when there's no real error to detect
         rel = abs(totals%dH_dstate2_fd - totals%dH_dstate2) / &
-              max(max(abs(totals%dH_dstate2_fd), abs(totals%dH_dstate2)), 1.0d-8)
+              max(max(abs(totals%dH_dstate2_fd), abs(totals%dH_dstate2)), 1.0d-3)
         write(*,*) "dH/dstate2: an=", totals%dH_dstate2, " fd=", totals%dH_dstate2_fd, " rel=", rel
         @assertLessThan(rel, tol)
         rel = maxval(abs(totals%dH_dw0_fd - totals%dH_dw0) / &
-                     max(max(abs(totals%dH_dw0_fd), abs(totals%dH_dw0)), 1.0d-8))
+                     max(max(abs(totals%dH_dw0_fd), abs(totals%dH_dw0)), 1.0d-1))
         do i = 1, solver%num_reactants
             write(*,*) "dH/dw0(", i, "): an=", totals%dH_dw0(i), " fd=", totals%dH_dw0_fd(i)
         end do
@@ -1931,7 +1933,7 @@ contains
         type(EqDerivatives) :: totals
         real(dp) :: s_reac, p_reac, weights(2)
         real(dp), parameter :: h = 1.0d-6
-        real(dp), parameter :: tol = 1.0d30
+        real(dp), parameter :: tol = 5.0d-2
         real(dp) :: rel
         ! integer :: i
 
@@ -2029,10 +2031,14 @@ contains
         rel = abs(totals%dS_dstate1_fd - totals%dS_dstate1) / max(abs(totals%dS_dstate1), 1.0d-30)
         ! write(*,*) "dS/dstate1: an=", totals%dS_dstate1, " fd=", totals%dS_dstate1_fd, " rel=", rel
         @assertLessThan(rel, tol)
-        rel = abs(totals%dS_dstate2_fd - totals%dS_dstate2) / max(abs(totals%dS_dstate2), 1.0d-30)
+        ! dS/dstate2 = 0 for sp (S is pinned regardless of P); floor absorbs FD noise here when there's no real error to detect
+        rel = abs(totals%dS_dstate2_fd - totals%dS_dstate2) / &
+              max(max(abs(totals%dS_dstate2_fd), abs(totals%dS_dstate2)), 1.0d-3)
         ! write(*,*) "dS/dstate2: an=", totals%dS_dstate2, " fd=", totals%dS_dstate2_fd, " rel=", rel
         @assertLessThan(rel, tol)
-        rel = maxval(abs(totals%dS_dw0_fd - totals%dS_dw0) / max(abs(totals%dS_dw0), 1.0d-30))
+        ! dS/dw0 = 0 for sp (S is pinned regardless of w0); floor absorbs FD noise here when there's no real error to detect
+        rel = maxval(abs(totals%dS_dw0_fd - totals%dS_dw0) / &
+                     max(max(abs(totals%dS_dw0_fd), abs(totals%dS_dw0)), 1.0d-1))
         ! do i = 1, solver%num_reactants
             ! write(*,*) "dS/dw0(", i, "): an=", totals%dS_dw0(i), " fd=", totals%dS_dw0_fd(i)
         ! end do
@@ -2063,7 +2069,7 @@ contains
         type(EqDerivatives) :: totals
         real(dp) :: s_reac, p_reac, weights(2)
         real(dp), parameter :: h = 1.0d-6
-        real(dp), parameter :: tol = 1.0d30
+        real(dp), parameter :: tol = 5.0d-2
         real(dp) :: rel
         integer :: i
 
@@ -2161,10 +2167,14 @@ contains
         rel = abs(totals%dS_dstate1_fd - totals%dS_dstate1) / max(abs(totals%dS_dstate1), 1.0d-30)
         write(*,*) "dS/dstate1: an=", totals%dS_dstate1, " fd=", totals%dS_dstate1_fd, " rel=", rel
         @assertLessThan(rel, tol)
-        rel = abs(totals%dS_dstate2_fd - totals%dS_dstate2) / max(abs(totals%dS_dstate2), 1.0d-30)
+        ! dS/dstate2 = 0 for sp (S is pinned regardless of P); floor absorbs FD noise here when there's no real error to detect
+        rel = abs(totals%dS_dstate2_fd - totals%dS_dstate2) / &
+              max(max(abs(totals%dS_dstate2_fd), abs(totals%dS_dstate2)), 1.0d-3)
         write(*,*) "dS/dstate2: an=", totals%dS_dstate2, " fd=", totals%dS_dstate2_fd, " rel=", rel
         @assertLessThan(rel, tol)
-        rel = maxval(abs(totals%dS_dw0_fd - totals%dS_dw0) / max(abs(totals%dS_dw0), 1.0d-30))
+        ! dS/dw0 = 0 for sp (S is pinned regardless of w0); floor absorbs FD noise here when there's no real error to detect
+        rel = maxval(abs(totals%dS_dw0_fd - totals%dS_dw0) / &
+                     max(max(abs(totals%dS_dw0_fd), abs(totals%dS_dw0)), 1.0d-1))
         do i = 1, solver%num_reactants
             write(*,*) "dS/dw0(", i, "): an=", totals%dS_dw0(i), " fd=", totals%dS_dw0_fd(i)
         end do
@@ -2605,7 +2615,8 @@ contains
         type(EqDerivatives) :: totals
         real(dp) :: v_reac, u_reac, weights(3)
         real(dp), parameter :: h = 1.0d-6
-        real(dp), parameter :: tol = 1.0d30
+        real(dp), parameter :: tol = 5.0d-2
+        real(dp), parameter :: tol_dU_dstate2 = 1.0d30
         real(dp) :: rel
         ! integer :: i
 
@@ -2701,14 +2712,16 @@ contains
         rel = abs(totals%dU_dstate1_fd - totals%dU_dstate1) / max(abs(totals%dU_dstate1), 1.0d-30)
         ! write(*,*) "dU/dstate1: an=", totals%dU_dstate1, " fd=", totals%dU_dstate1_fd, " rel=", rel
         @assertLessThan(rel, tol)
+        ! dU/dstate2 = 0 for uv, but FD noise here is unusually large; left unfailable pending separate investigation
         rel = abs(totals%dU_dstate2_fd - totals%dU_dstate2) / max(abs(totals%dU_dstate2), 1.0d-30)
         ! write(*,*) "dU/dstate2: an=", totals%dU_dstate2, " fd=", totals%dU_dstate2_fd, " rel=", rel
-        @assertLessThan(rel, tol)
+        @assertLessThan(rel, tol_dU_dstate2)
+        ! dU/dw0 = 0 for uv, same reasoning as dU/dstate2 above; routed through the same unfailable bound
         rel = maxval(abs(totals%dU_dw0_fd - totals%dU_dw0) / max(abs(totals%dU_dw0), 1.0d-30))
         ! do i = 1, solver%num_reactants
             ! write(*,*) "dU/dw0(", i, "): an=", totals%dU_dw0(i), " fd=", totals%dU_dw0_fd(i)
         ! end do
-        @assertLessThan(rel, tol)
+        @assertLessThan(rel, tol_dU_dstate2)
 
         rel = abs(totals%dG_dstate1_fd - totals%dG_dstate1) / max(abs(totals%dG_dstate1), 1.0d-30)
         ! write(*,*) "dG/dstate1: an=", totals%dG_dstate1, " fd=", totals%dG_dstate1_fd, " rel=", rel
@@ -2758,7 +2771,8 @@ contains
         type(EqDerivatives) :: totals
         real(dp) :: v_reac, u_reac, weights(3)
         real(dp), parameter :: h = 1.0d-6
-        real(dp), parameter :: tol = 1.0d30
+        real(dp), parameter :: tol = 5.0d-2
+        real(dp), parameter :: tol_dU_dstate2 = 1.0d30
         real(dp) :: rel
         integer :: i
 
@@ -2854,14 +2868,16 @@ contains
         rel = abs(totals%dU_dstate1_fd - totals%dU_dstate1) / max(abs(totals%dU_dstate1), 1.0d-30)
         write(*,*) "dU/dstate1: an=", totals%dU_dstate1, " fd=", totals%dU_dstate1_fd, " rel=", rel
         @assertLessThan(rel, tol)
+        ! dU/dstate2 = 0 for uv, but FD noise here is unusually large; left unfailable pending separate investigation
         rel = abs(totals%dU_dstate2_fd - totals%dU_dstate2) / max(abs(totals%dU_dstate2), 1.0d-30)
         write(*,*) "dU/dstate2: an=", totals%dU_dstate2, " fd=", totals%dU_dstate2_fd, " rel=", rel
-        @assertLessThan(rel, tol)
+        @assertLessThan(rel, tol_dU_dstate2)
+        ! dU/dw0 = 0 for uv, same reasoning as dU/dstate2 above; routed through the same unfailable bound
         rel = maxval(abs(totals%dU_dw0_fd - totals%dU_dw0) / max(abs(totals%dU_dw0), 1.0d-30))
         do i = 1, solver%num_reactants
             write(*,*) "dU/dw0(", i, "): an=", totals%dU_dw0(i), " fd=", totals%dU_dw0_fd(i)
         end do
-        @assertLessThan(rel, tol)
+        @assertLessThan(rel, tol_dU_dstate2)
 
         rel = abs(totals%dG_dstate1_fd - totals%dG_dstate1) / max(abs(totals%dG_dstate1), 1.0d-30)
         write(*,*) "dG/dstate1: an=", totals%dG_dstate1, " fd=", totals%dG_dstate1_fd, " rel=", rel
@@ -2985,7 +3001,7 @@ contains
         type(EqDerivatives) :: totals
         real(dp) :: s_reac, v_reac, of_ratio, weights(2)
         real(dp), parameter :: h = 1.0d-6
-        real(dp), parameter :: tol = 1.0d30
+        real(dp), parameter :: tol = 5.0d-2
         real(dp) :: rel
         ! integer :: i
 
@@ -3032,9 +3048,12 @@ contains
                      max(max(abs(totals%dn_dw0_fd), abs(totals%dn_dw0)), 1.0d-8))
         @assertLessThan(rel, tol)
 
-        rel = maxval(abs(totals%dnj_dstate1_fd - totals%dnj_dstate1) / max(abs(totals%dnj_dstate1), 1.0d-30))
+        ! Unlike sibling dnj_dstate checks, this floor wasn't shared with fd, so near-zero species noise could blow up the ratio
+        rel = maxval(abs(totals%dnj_dstate1_fd - totals%dnj_dstate1) / &
+                     max(max(abs(totals%dnj_dstate1_fd), abs(totals%dnj_dstate1)), 1.0d-8))
         @assertLessThan(rel, tol)
-        rel = maxval(abs(totals%dnj_dstate2_fd - totals%dnj_dstate2) / max(abs(totals%dnj_dstate2), 1.0d-30))
+        rel = maxval(abs(totals%dnj_dstate2_fd - totals%dnj_dstate2) / &
+                     max(max(abs(totals%dnj_dstate2_fd), abs(totals%dnj_dstate2)), 1.0d-8))
         @assertLessThan(rel, tol)
         rel = maxval(abs(totals%dnj_dw0_fd - totals%dnj_dw0) / max(abs(totals%dnj_dw0), 1.0d-30))
         @assertLessThan(rel, tol)
@@ -3078,10 +3097,14 @@ contains
         rel = abs(totals%dS_dstate1_fd - totals%dS_dstate1) / max(abs(totals%dS_dstate1), 1.0d-30)
         ! write(*,*) "dS/dstate1: an=", totals%dS_dstate1, " fd=", totals%dS_dstate1_fd, " rel=", rel
         @assertLessThan(rel, tol)
-        rel = abs(totals%dS_dstate2_fd - totals%dS_dstate2) / max(abs(totals%dS_dstate2), 1.0d-30)
+        ! dS/dstate2 = 0 for sv (S is pinned regardless of V); floor absorbs FD noise here when there's no real error to detect
+        rel = abs(totals%dS_dstate2_fd - totals%dS_dstate2) / &
+              max(max(abs(totals%dS_dstate2_fd), abs(totals%dS_dstate2)), 1.0d-3)
         ! write(*,*) "dS/dstate2: an=", totals%dS_dstate2, " fd=", totals%dS_dstate2_fd, " rel=", rel
         @assertLessThan(rel, tol)
-        rel = maxval(abs(totals%dS_dw0_fd - totals%dS_dw0) / max(abs(totals%dS_dw0), 1.0d-30))
+        ! dS/dw0 = 0 for sv (S is pinned regardless of w0); floor absorbs FD noise here when there's no real error to detect
+        rel = maxval(abs(totals%dS_dw0_fd - totals%dS_dw0) / &
+                     max(max(abs(totals%dS_dw0_fd), abs(totals%dS_dw0)), 1.0d-1))
         ! do i = 1, solver%num_reactants
             ! write(*,*) "dS/dw0(", i, "): an=", totals%dS_dw0(i), " fd=", totals%dS_dw0_fd(i)
         ! end do
@@ -3112,7 +3135,7 @@ contains
         type(EqDerivatives) :: totals
         real(dp) :: s_reac, v_reac, of_ratio, weights(2)
         real(dp), parameter :: h = 1.0d-6
-        real(dp), parameter :: tol = 1.0d30
+        real(dp), parameter :: tol = 5.0d-2
         real(dp) :: rel
         integer :: i
 
@@ -3159,9 +3182,12 @@ contains
                      max(max(abs(totals%dn_dw0_fd), abs(totals%dn_dw0)), 1.0d-8))
         @assertLessThan(rel, tol)
 
-        rel = maxval(abs(totals%dnj_dstate1_fd - totals%dnj_dstate1) / max(abs(totals%dnj_dstate1), 1.0d-30))
+        ! Unlike sibling dnj_dstate checks, this floor wasn't shared with fd, so near-zero species noise could blow up the ratio
+        rel = maxval(abs(totals%dnj_dstate1_fd - totals%dnj_dstate1) / &
+                     max(max(abs(totals%dnj_dstate1_fd), abs(totals%dnj_dstate1)), 1.0d-8))
         @assertLessThan(rel, tol)
-        rel = maxval(abs(totals%dnj_dstate2_fd - totals%dnj_dstate2) / max(abs(totals%dnj_dstate2), 1.0d-30))
+        rel = maxval(abs(totals%dnj_dstate2_fd - totals%dnj_dstate2) / &
+                     max(max(abs(totals%dnj_dstate2_fd), abs(totals%dnj_dstate2)), 1.0d-8))
         @assertLessThan(rel, tol)
         rel = maxval(abs(totals%dnj_dw0_fd - totals%dnj_dw0) / max(abs(totals%dnj_dw0), 1.0d-30))
         @assertLessThan(rel, tol)
@@ -3205,10 +3231,14 @@ contains
         rel = abs(totals%dS_dstate1_fd - totals%dS_dstate1) / max(abs(totals%dS_dstate1), 1.0d-30)
         write(*,*) "dS/dstate1: an=", totals%dS_dstate1, " fd=", totals%dS_dstate1_fd, " rel=", rel
         @assertLessThan(rel, tol)
-        rel = abs(totals%dS_dstate2_fd - totals%dS_dstate2) / max(abs(totals%dS_dstate2), 1.0d-30)
+        ! dS/dstate2 = 0 for sv (S is pinned regardless of V); floor absorbs FD noise here when there's no real error to detect
+        rel = abs(totals%dS_dstate2_fd - totals%dS_dstate2) / &
+              max(max(abs(totals%dS_dstate2_fd), abs(totals%dS_dstate2)), 1.0d-3)
         write(*,*) "dS/dstate2: an=", totals%dS_dstate2, " fd=", totals%dS_dstate2_fd, " rel=", rel
         @assertLessThan(rel, tol)
-        rel = maxval(abs(totals%dS_dw0_fd - totals%dS_dw0) / max(abs(totals%dS_dw0), 1.0d-30))
+        ! dS/dw0 = 0 for sv (S is pinned regardless of w0); floor absorbs FD noise here when there's no real error to detect
+        rel = maxval(abs(totals%dS_dw0_fd - totals%dS_dw0) / &
+                     max(max(abs(totals%dS_dw0_fd), abs(totals%dS_dw0)), 1.0d-1))
         do i = 1, solver%num_reactants
             write(*,*) "dS/dw0(", i, "): an=", totals%dS_dw0(i), " fd=", totals%dS_dw0_fd(i)
         end do


### PR DESCRIPTION
## Summary

Eight `pFUnit` test subroutines in `source/equilibrium_test.pf` compared analytic vs. finite-difference derivatives using `tol = 1.0d30`, which cannot fail for any finite value — a wrong Jacobian entry in the `hp`/`sp`/`uv`/`sv` constraint paths would pass silently. This replaces those with real tolerances, matching the sibling `tp`/`tv` tests.

Already reviewed and merged on the fork: https://github.com/djkees/cea/pull/212 (originally filed as https://github.com/djkees/cea/issues/88)

## Changes

- Replaced all 8 `tol = 1.0d30` declarations with `tol = 5.0d-2` (matching `tp`/`tv`).
- That alone wasn't sufficient: several assertions compare a derivative that is analytically exactly zero — the constrained "held-fixed" output quantity's sensitivity to the constraint's other input (`state2` or `w0`) — against pure finite-difference/solver noise, using a denominator floor that was either too tight or missing entirely. Fixed the floor on these specific assertions, each sized differently depending on why it needed changing:

  | Assertion(s) | Old floor | New floor | How it was chosen |
  |---|---|---|---|
  | `hp` `dH/dstate2` | `1.0d-8` (shared, too tight) | `1.0d-3` | Measured noise ~2e-5; raised to give ~50x margin, still ~1000x below the smallest genuine nonzero value of this quantity seen elsewhere in the file |
  | `hp` `dH/dw0` | `1.0d-8` (shared, too tight) | `1.0d-1` | Measured noise reached ~9.3e-4; needed >1.85e-2 to pass under `tol=5e-2`, so used `1e-1` for comfortable margin |
  | `sp` `dS/dstate2` | `1.0d-30` (unshared, missing) | `1.0d-3` | Measured noise ~1.2e-7; reused `hp`'s `dH/dstate2` floor value (same order-of-magnitude problem) |
  | `sp` `dS/dw0` | `1.0d-30` (unshared, missing) | `1.0d-1` | Measured noise ~1.6e-5; used the same `1e-1` value as `hp`'s `dH/dw0` for consistency across all `dw0` pinned-quantity checks |
  | `sv` `dS/dstate2` | `1.0d-30` (unshared, missing) | `1.0d-3` | Same quantity/scale as `sp`'s `dS/dstate2`; matched for consistency |
  | `sv` `dS/dw0` | `1.0d-30` (unshared, missing) | `1.0d-1` | Same reasoning as `hp`/`sp`'s `dw0` floor |
  | `sv` `dnj_dstate1`, `dnj_dstate2` | `1.0d-30` (unshared, missing) | `1.0d-8` | Not newly sized — matched the floor value already used in the equivalent, correct `dnj_dstate` assertions in `hp`/`tp`/`uv`; `sv`'s own measured noise (~1e-24) was comfortably below even that |

  All chosen floors stay far below the smallest genuine nonzero derivative magnitude observed for that same quantity elsewhere in the file, so a real regression (order-1 or larger, not noise-level) still trips the assertion.

- `uv`'s two analogous directions (`dU/dstate2`, `dU/dw0`) have unusually large FD noise (up to ~3.7e-2, vs. ~1e-7-1e-3 for the equivalent `hp`/`sp`/`sv` checks) — large enough that a safe floor (>0.74, by the same margin math above) would exceed several genuine nonzero derivative values elsewhere in the same file. Left these two assertions at the original unfailable bound (now a dedicated `tol_dU_dstate2` parameter, not the shared `tol`) with an explanatory comment, and opened a follow-up on the fork rather than papering over it: https://github.com/djkees/cea/issues/211

- Test-only change; no solver/algorithm code touched.

## Testing

```
cmake --preset dev -DCMAKE_PREFIX_PATH=build-dev/install
cmake --build build-dev
ctest -R cea_core_test -V   # 124/124 pFUnit tests pass
ctest                        # full suite, 16/16 test executables pass
```

Also verified the fix actually catches regressions, and that the old tolerance wouldn't have: temporarily flipped a sign in a Jacobian term in `source/equilibrium.f90` (reverted before this PR) and ran the same injected bug against both versions of the test file:

| Test | old `tol = 1.0d30` + bug | new tolerances + same bug |
|---|---|---|
| `test_hp_derivatives_fd` | passes (silent) | **fails** |
| `test_hp_derivatives_fd_smooth_truncation` | passes (silent) | **fails** |
| `test_sp_derivatives_fd` | passes (silent) | **fails** |
| `test_sp_derivatives_fd_smooth_truncation` | passes (silent) | **fails** |

## Compatibility / Numerical behavior
- [x] No expected changes to numerical results

Test-only change (`source/equilibrium_test.pf`); no changes to solver algorithms, tolerances, or convergence logic in `source/equilibrium.f90` or elsewhere.

---

Drafted with Claude's assistance
- Every tolerance/formula change and its rationale was verified against actual `ctest -R cea_core_test -V` output (analytic vs. FD values via the test file's own debug prints), not estimated.
- The fix's ability to catch a real bug, and the old tolerance's failure to, were both independently confirmed via a temporary, reverted sign-flip injection (see Testing section).
