### PR TITLE
Document Excel UDF thread-safety guarantee

### DIFF
--- a/source/bind/excel/README.md
+++ b/source/bind/excel/README.md
@@ -25,6 +25,15 @@ Platform support
 - Not supported: macOS Excel/VBA, 32-bit Office, XLL, or Office.js.
 - Do not attempt to use the workbook interface outside 64-bit Windows Excel.
 
+Thread safety
+-------------
+Excel always calls VBA user-defined functions, including these worksheet
+UDFs, serially on its single main thread; the multithreaded recalculation
+engine never dispatches them to worker threads. So `cea_excel.dll` is never
+entered concurrently and needs no internal locking today. See
+[Multithreaded recalculation in Excel](https://learn.microsoft.com/en-us/office/client-developer/excel/multithreaded-recalculation-in-excel),
+under "What is and is not considered thread safe by Excel".
+
 Installation overview
 ---------------------
 1. Build the native `cea_excel.dll` on 64-bit Windows.

--- a/source/bind/excel/src/cea_excel_api.c
+++ b/source/bind/excel/src/cea_excel_api.c
@@ -1,3 +1,4 @@
+/* Thread safety: see "Thread safety" in ../README.md. */
 #include "cea_excel.h"
 
 #include "cea.h"

--- a/source/bind/excel/vba/modCEADeclare.bas
+++ b/source/bind/excel/vba/modCEADeclare.bas
@@ -2,6 +2,7 @@ Attribute VB_Name = "modCEADeclare"
 Option Explicit
 
 #If Win64 Then
+    ' Thread safety: see "Thread safety" in ../README.md.
     Private Const CEA_EXCEL_DLL_NAME As String = "cea_excel.dll"
     Private Const LOAD_WITH_ALTERED_SEARCH_PATH As Long = &H8
 


### PR DESCRIPTION
## Summary
Documents why the Excel/VBA UDF (User-Defined Function) interface (`source/bind/excel/`) never needs internal locking around `cea_excel.dll`, closing a documentation gap raised in a fork issue (https://github.com/djkees/cea/issues/193). `modCEAUDF.bas`'s functions are plain VBA `Declare`-based UDFs, and Excel's own documentation states VBA UDFs are always called serially on its single main thread, never dispatched to multithreaded-recalculation worker threads. `Application.MacroOptions ThreadSafe` only applies to XLL-registered functions — XLLs are a separate, compiled-DLL-based Excel add-in mechanism, distinct from the VBA macros used here — which this interface doesn't use. So `cea_excel.dll` can never actually be entered concurrently through this interface — the invariant was already true, just undocumented.

## Changes
- Adds a short "Thread safety" section to `source/bind/excel/README.md`, citing [Microsoft's multithreaded recalculation documentation](https://learn.microsoft.com/en-us/office/client-developer/excel/multithreaded-recalculation-in-excel).
- Adds a one-line comment in `source/bind/excel/src/cea_excel_api.c` (the native wrapper implementation, where the process-global CEA state this matters for actually lives) pointing back to that section.
- Adds a matching one-line comment in `source/bind/excel/vba/modCEADeclare.bas`, next to where `cea_excel.dll` is named and declared (the actual DLL boundary), rather than in `modCEAUDF.bas`'s business-logic code.

No mutex/critical-section code was added, since it would be defensive code for a scenario that can't occur under the current VBA `Declare`-based architecture.

## Testing
- Not run — comment/documentation-only change; no code behavior is affected. Verified by reviewing the diff directly.

## Compatibility / Numerical behavior
- [x] No expected changes to numerical results
- [ ] Expected changes (explain and provide validation)

Drafted with Claude's assistance
- Verified by fetching Microsoft's official "Multithreaded recalculation in Excel" documentation directly and cross-checking its explicit list of thread-unsafe function categories (VBA UDFs are listed by name), plus reading `modCEAUDF.bas`, `modCEADeclare.bas`, and `cea_excel_api.c` in full to confirm the interface uses VBA `Declare` bindings rather than an XLL, and that no XLL-related scaffolding exists anywhere in `source/bind/excel/` to clean up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
