### PR TITLE
Fix shock.f90 paired-field declarations to default-init both fields

### DIFF
--- a/source/shock.f90
+++ b/source/shock.f90
@@ -62,13 +62,13 @@ module cea_shock
             !! incident-state frozen Cp basis at the reflected temperature.
 
         ! Solution variables
-        real(dp) :: rho12, rho52 = 0.0d0
+        real(dp) :: rho12 = 0.0d0, rho52 = 0.0d0
             !! Ratios of density across the incident and reflected shocks
-        real(dp) :: p21, p52 = 0.0d0
+        real(dp) :: p21 = 0.0d0, p52 = 0.0d0
             !! Pressure ratios across the incident and reflected shocks
-        real(dp) :: t21, t52 = 0.0d0
+        real(dp) :: t21 = 0.0d0, t52 = 0.0d0
             !! Temperature ratios across the incident and reflected shocks
-        real(dp) :: M21, M52 = 0.0d0
+        real(dp) :: M21 = 0.0d0, M52 = 0.0d0
             !! Molecular-weight ratios M2/M1 and M5/M2 (legacy CEA2 output), not Mach ratios.
         real(dp) :: v2 = 0.0d0
             !! Station-2 gas speed in the wall/unshocked-gas frame: u(1)-u(2) [m/s].


### PR DESCRIPTION
## Summary

`ShockSolution`'s field-pair declarations in `source/shock.f90` (`rho12`/`rho52`, `p21`/`p52`, `t21`/`t52`, `M21`/`M52`) put `= 0.0d0` at the end of a comma-separated declaration list. In Fortran that initializer only applies to the trailing name, so `rho52`, `p52`, `t52`, and `M52` defaulted to `0.0d0` while `rho12`, `p21`, `t21`, and `M21` got no default at all, despite reading as a paired declaration.

https://github.com/djkees/cea/issues/67

## Changes

- Gave each of the eight fields its own explicit `= 0.0d0` initializer instead of relying on one shared trailing initializer per pair.
- No logic, control flow, or numerical behavior touched — declarations only.

## Testing
```
cmake --preset core -B build-core
cmake --build build-core
```
`shock.f90.obj` builds clean with no errors or warnings under the Fortran-only `core` preset. This same diff also passed the full fork CI matrix (all OS/compiler legs, Python, wheels, pFUnit) on `djkees/cea#221`.

## Compatibility / Numerical behavior
- [x] No expected changes to numerical results
- [ ] Expected changes (explain and provide validation)

Every current call site (`source/shock.f90:214-217,245-255,533-537,563-567`) already assigns all eight fields explicitly before use, so this closes a latent uninitialized-read gap without changing any existing behavior.

---

Drafted with Claude's assistance
- The declaration lines and the explicit-assignment call sites were confirmed by direct read of `source/shock.f90`.
- The fix was verified to compile cleanly under the `core` preset build shown above, and the identical diff passed the full CI matrix on the fork PR before this cherry-pick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
