### PR TITLE
Abort with a clear error instead of silently truncating schedule/formula overflow

### DIFF
--- a/source/input.f90
+++ b/source/input.f90
@@ -517,7 +517,7 @@ contains
                 cycle
             end if
             if (is_formula_element_token(token)) then
-                reac(n)%formula = parse_formula(scanner, token)
+                reac(n)%formula = parse_formula(scanner, token, reac(n)%name)
                 cycle
             end if
             select case(token_lower(1:1))
@@ -787,12 +787,25 @@ contains
             end if
         end do
 
+        ! If the loop above filled every slot without running out of input,
+        ! check whether another value follows: if so, the schedule has more
+        ! values than max_values allows and was silently truncated above.
+        if (i > max_values) then
+            val = scanner%peek_real(ierr)
+            if (ierr == 0) then
+                call abort('parse_schedule: too many values for '//trim(sched%name)// &
+                    '; accepts at most '//to_str(max_values)//' values')
+            end if
+        end if
+
         return
     end function
 
-    function parse_formula(scanner, token) result(f)
+    function parse_formula(scanner, token, context) result(f)
         type(string_scanner), intent(inout) :: scanner
         character(*), intent(in) :: token
+        character(*), intent(in), optional :: context
+            !! Name of the reactant this formula belongs to, for error messages
 
         type(Formula) :: f
         integer, parameter :: max_values = 16
@@ -829,6 +842,23 @@ contains
             if (ierr == 0) f%coefficients(i) = scanner%read_real(ierr)
             n = i
         end do
+
+        ! If the loop above filled every slot without hitting the end of the
+        ! formula, check whether another element token follows: if so, the
+        ! formula has more terms than max_values allows and was silently
+        ! truncated above.
+        if (i > max_values) then
+            word = scanner%peek_word(ierr)
+            if (ierr == 0 .and. is_formula_element_token(word)) then
+                if (present(context)) then
+                    call abort('parse_formula: too many elements in formula for '//trim(context)// &
+                        '; accepts at most '//to_str(max_values)//' elements')
+                else
+                    call abort('parse_formula: too many elements in formula; accepts at most '// &
+                        to_str(max_values)//' elements')
+                end if
+            end if
+        end if
 
         f%elements = f%elements(:n)
         f%coefficients = f%coefficients(:n)

--- a/source/input_test.pf
+++ b/source/input_test.pf
@@ -96,6 +96,26 @@ contains
     end subroutine
 
     @test
+    subroutine test_parse_schedule_at_max_values
+        ! Exactly 64 values (the schedule limit) should parse without
+        ! error, guarding against an off-by-one in the too-many-values check.
+        character(:), allocatable :: token
+        type(string_scanner) :: scanner
+        type(Schedule) :: sch
+
+        scanner = string_scanner(replace_delimiters( &
+            't(k)=300,301,302,303,304,305,306,307,308,309,310,311,312,313,314,315,316,317,318,319,' // &
+            '320,321,322,323,324,325,326,327,328,329,330,331,332,333,334,335,336,337,338,339,' // &
+            '340,341,342,343,344,345,346,347,348,349,350,351,352,353,354,355,356,357,358,359,' // &
+            '360,361,362,363,'))
+        token = scanner%read_word()
+        sch = parse_schedule(scanner, token)
+        @assertEqual(64,     size(sch%values))
+        @assertEqual(363d0,  sch%values(64))
+
+    end subroutine
+
+    @test
     subroutine test_parse_species
         character(32), allocatable :: species(:)
         allocate(species(0))
@@ -198,6 +218,36 @@ contains
         @assertEqual(1.0d0, reac(1)%formula%coefficients(1))
         @assertEqual(1.0d0, reac(1)%formula%coefficients(2))
         @assertEqual(1.0d0, reac(1)%formula%coefficients(3))
+    end subroutine
+
+    @test
+    subroutine test_parse_formula_at_max_values
+        ! Exactly 16 elements (the formula limit) should parse without
+        ! error, guarding against an off-by-one in the too-many-elements check.
+        type(ReactantInput), allocatable :: reac(:)
+        allocate(reac(0))
+
+        reac = parse_reac('reac name=HTPB wt%=100 H C N O F S P K B AL MG CA ZN CU AG AU')
+        @assertEqual(16, size(reac(1)%formula%elements))
+        @assertEqual('AU', reac(1)%formula%elements(16))
+    end subroutine
+
+    @test
+    subroutine test_parse_formula_without_context
+        ! parse_formula's `context` argument is optional; parse_reac is
+        ! currently its only caller and always supplies one, so exercise
+        ! the argument-omitted call directly to confirm it still works.
+        character(:), allocatable :: token
+        type(string_scanner) :: scanner
+        type(Formula) :: f
+
+        scanner = string_scanner(replace_delimiters('C 1 H 4'))
+        token = scanner%read_word()
+        f = parse_formula(scanner, token)
+        @assertEqual(2,     size(f%elements))
+        @assertEqual('C',   f%elements(1))
+        @assertEqual('H',   f%elements(2))
+        @assertEqual(4.0d0, f%coefficients(2))
     end subroutine
 
     @test


### PR DESCRIPTION
## Summary

`parse_schedule` (64-value limit) and `parse_formula` (16-element limit) in `source/input.f90` silently truncated input once their fixed-size arrays filled up, with no check that the input was actually exhausted. The leftover tokens were left for the caller to trip over, producing a confusing `"unrecognized token"` error instead of one that names the real problem.

## Changes

- After each fill loop, if it ran to completion without an early exit, peek at the next token. If one is still there, `abort()` with a message identifying the limit and (where available) the specific schedule/reactant name involved, e.g.:
  - `parse_schedule: too many values for t; accepts at most 64 values`
  - `parse_formula: too many elements in formula for TestFormula; accepts at most 16 elements`
- `parse_formula` gained an optional `context` argument (the reactant name) so its error message can name which reactant's formula overflowed; `parse_reac` (its only caller) passes `reac(n)%name` through.
- Added three pFUnit regression tests in `source/input_test.pf` covering the exact-boundary cases (64 values / 16 elements parse cleanly, guarding against an off-by-one in the new check) and the `parse_formula` call with `context` omitted.
- No numerical/solver logic changed — this is input-validation in the legacy `.inp` parser only.
- Already reviewed and merged on the fork: https://github.com/djkees/cea/pull/220

## Testing
- `ctest -R cea_core_test -V` — 127/127 pFUnit tests passing, including the 3 new ones (run on this branch as cherry-picked onto `upstream/main`, not just on the fork)
- Manual CLI verification (`cea.exe`) against crafted `.inp` files: a 70-value `t` schedule and a 17-element formula both now abort with the specific new error messages; the exact-boundary cases (64 values / 16 elements) still parse and run without a false-positive abort; the unmodified `samples/example1.inp` baseline still runs to completion (exit 0) with unchanged output

## Compatibility / Numerical behavior
- [x] No expected changes to numerical results

This only changes behavior for inputs that already exceeded the parser limits, which previously always failed anyway (just with a misleading error). No currently-working input is affected.

---
Drafted with Claude's assistance
- The truncation behavior and lack of an exhaustion check were confirmed by direct read of `source/input.f90:756-837` before the fix.
- The claim that overflow always failed before this fix (never silently succeeded) was verified by tracing the parser control flow: truncated leftover tokens are always non-keyword values that the next parse step can't consume as a keyword, which is what `parse_prob`'s existing "unrecognized token" abort was already catching.
- All test results above were run directly in this session (both on the fork branch and again after cherry-picking onto `upstream/main`), not summarized from memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)